### PR TITLE
Use catalog-driven runtime model limits

### DIFF
--- a/.memory/PROJECT-HISTORY.md
+++ b/.memory/PROJECT-HISTORY.md
@@ -1,5 +1,13 @@
 # Project History
 
+### 2026-07-23 — Resolve runtime limits from Pi and the bundled model catalog
+
+- Replaced the hardcoded text-only `128K/8192` non-Codex runtime model with field-by-field resolution from connection-discovered per-model overrides, provider-scoped Pi exact metadata, the packaged offline model snapshot, and the conservative fallback.
+- Matched Pi's provider composition: mapped built-in providers retain their model metadata when routed through a proxy, while unknown custom provider IDs cannot borrow Pi or bundled entries from another provider.
+- Made the resolved runtime model's input capabilities the sole image gate for generation and chat titles, so display-only Artificial Analysis metadata cannot re-enable images or Computer Use.
+- Added a one-shot shared packaged-catalog loader that fails closed on missing, malformed, or diagnostic failures without adding runtime models.dev or Artificial Analysis requests. Native Google transport remains deferred to Gemini Phase 1.
+- Covered catalog hit/miss/partial resolution, proxy routing, connection overrides, provider isolation, actual bundled Gemini limits, loader failure/concurrency, transport preservation, and image gating. Two fresh adversarial reviews found no remaining issue; all 629 TypeScript/JavaScript tests, all 41 Rust tests, type-check, lint, production build, and diff validation pass.
+
 ### 2026-07-23 — Animate the terminal drawer opening
 
 - The workspace terminal now expands upward from the chat edge over 300ms with the app's existing enter easing, using its persisted drawer height instead of appearing abruptly.

--- a/docs/gemini-native-upgrade-plan.md
+++ b/docs/gemini-native-upgrade-plan.md
@@ -1,6 +1,6 @@
 # Gemini Native Upgrade Plan
 
-Status: implementation plan only
+Status: Phase 0 implemented on 2026-07-23; Phases 1 and 3 remain planned
 Date: 2026-07-22
 Depends on: `docs/pi-provider-integration-plan.md` (broader registry migration)
 Pi packages pinned: `@earendil-works/pi-ai` / `@earendil-works/pi-agent-core` `0.80.10`
@@ -25,9 +25,9 @@ Verified against the current codebase:
 | Gap | Evidence | Consequence |
 | --- | --- | --- |
 | Gemini chat rides the OpenAI-compat endpoint | `main/services/config-store.ts:52-61` (`kind: "openai"`, `baseUrl: .../v1beta/openai`), `main/services/model-runtime-core.ts:33-35` | Native Gemini features (system instructions, safety settings, `responseSchema`, thinking config, context caching) are unreachable. |
-| Runtime limits are fabricated | `main/services/model-runtime-core.ts:37-49` hardcodes `contextWindow: 128_000`, `maxTokens: 8192`, `reasoning: false` for every non-Codex model | Gemini's true ~1M context and 65K output (2.5 Pro/Flash) are throttled to 128K/8K. |
-| Catalog already knows the real limits | `resources/model-capabilities.json` → `models-catalog-core.ts:104-105` → `model-picker.tsx:88-89` (UI display only) | The data exists but is never wired into the runtime `Model`. |
-| No reasoning UI or payload mapping | `model-picker-pad.tsx` is selection-only; no `thinkingConfig` anywhere; `model-runtime-core.ts:44` sets `reasoning: false` | Users cannot control Gemini thinking budget/level. |
+| Runtime limits were fabricated | Before Phase 0, `model-runtime-core.ts` hardcoded `contextWindow: 128_000`, `maxTokens: 8192`, `reasoning: false`, and text-only input for every non-Codex model. | Phase 0 now resolves connection-discovered overrides over provider-scoped Pi metadata, then the bundled snapshot and conservative fallback. |
+| Catalog already knows the real limits | `resources/model-capabilities.json` → `models-catalog-core.ts` → `models-catalog.ts` | Phase 0 now uses this offline snapshot for runtime limits as well as display metadata; the running app still makes no catalog network request. |
+| No reasoning UI or payload mapping | `model-picker-pad.tsx` is selection-only and no `thinkingConfig` is sent; Phase 0 now identifies reasoning-capable runtime models. | Users still cannot control Gemini thinking budget/level. |
 | No context caching | No `cachedContent`/`createCachedContent` in app TS; `usage-accounting.ts:27-36` only *reads* `cachedContentTokenCount` if returned | Workspace repo context is re-transmitted every turn, costing latency and tokens. |
 | Voice is one-shot REST, chat is OpenAI adapter | `main/services/transcription.ts:105-137` (`generateContent`) vs chat OpenAI-compat | Dual integration; voice stays one-shot (acceptable — Live is deferred). |
 
@@ -43,6 +43,8 @@ Verified against the current codebase:
 ## Phase 0 — Catalog-driven runtime limits
 
 The fastest correct fix: stop fabricating `128K/8192` and feed the release-bundled capability snapshot into the runtime `Model`. This helps **all** providers, not just Gemini, and ships before any transport change.
+
+**Implemented 2026-07-23.** Runtime resolution follows Pi's provider-owned model composition: a mapped built-in provider keeps its exact Pi metadata even when its base URL routes through a proxy, connection-discovered per-model fields override that metadata, the provider-scoped bundled snapshot fills remaining fields, and an unknown custom provider falls back conservatively without borrowing another provider's model. Image gating now reads only the resolved runtime model. The existing compatibility transport is intentionally unchanged until Phase 1.
 
 ### Files
 

--- a/main/services/chat-title.ts
+++ b/main/services/chat-title.ts
@@ -15,8 +15,8 @@ import {
 import { resolveChatTitleRoute } from "./chat-title-routing.js";
 import { configStore } from "./config-store.js";
 import { foundationModelsConnection } from "./foundation-models-connection.js";
+import { runtimeSupportsImages } from "./generation-runtime.js";
 import { resolveModelRuntime } from "./model-runtime.js";
-import { providerModelInfo } from "./provider-model-info.js";
 import {
   assistantUsageRecord,
   isLocalModelProvider,
@@ -86,7 +86,6 @@ async function generateWithChatModel(input: {
     input.selection.model,
     input.signal,
   );
-  const modelInfo = await providerModelInfo.info(input.selection.providerId, input.selection.model);
   const promptContent: Array<TextContent | ImageContent> = [
     {
       type: "text",
@@ -96,7 +95,7 @@ async function generateWithChatModel(input: {
   const firstImage = input.firstMessage.attachments?.find(
     (attachment) => attachment.kind === "image" && attachment.data,
   );
-  if (modelInfo.vision !== false && firstImage?.data) {
+  if (runtimeSupportsImages(runtime.model) && firstImage?.data) {
     promptContent.push({
       type: "image",
       data: firstImage.data,

--- a/main/services/generation-runtime.test.ts
+++ b/main/services/generation-runtime.test.ts
@@ -6,10 +6,10 @@ import type { Model, ProviderStreams } from "@earendil-works/pi-ai";
 import {
   PI_AUTH_COMPATIBILITY_TOKEN,
   buildAgentRuntimeOptions,
-  effectiveModelForGeneration,
   resolveRuntimeApiKey,
   resolveRuntimeBaseUrl,
   resolveRuntimeHeaders,
+  runtimeSupportsImages,
   settleGenerationCleanup,
   shouldExposeLocalReasoning,
   terminalAssistantReasoning,
@@ -20,6 +20,11 @@ import {
   terminalGenerationInterruptionError,
   terminalGenerationWasAborted,
 } from "./generation-runtime.js";
+
+test("uses only the connection-bound runtime model as the image gate", () => {
+  assert.equal(runtimeSupportsImages({ input: ["text"] }), false);
+  assert.equal(runtimeSupportsImages({ input: ["text", "image"] }), true);
+});
 
 test("clears transient agent state before bounded helper teardown", async () => {
   const events: string[] = [];
@@ -45,35 +50,6 @@ test("clears transient agent state before bounded helper teardown", async () => 
   assert.equal(completed, false);
   assert.equal(transientScreenshot, null);
   assert.deepEqual(events, ["reset", "close"]);
-});
-
-test("uses one positive, cloned image-capability snapshot for each generation", () => {
-  const textModel: Model<"openai-completions"> = {
-    id: "legacy",
-    name: "Legacy",
-    api: "openai-completions",
-    provider: "legacy",
-    baseUrl: "https://example.test/v1",
-    reasoning: false,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 128_000,
-    maxTokens: 8_192,
-  };
-  const originalInput = textModel.input;
-  const vision = effectiveModelForGeneration(textModel, true);
-  const unknown = effectiveModelForGeneration(textModel, undefined);
-  const negative = effectiveModelForGeneration(textModel, false);
-
-  assert.notEqual(vision, textModel);
-  assert.deepEqual(vision.input, ["text", "image"]);
-  assert.deepEqual(unknown.input, ["text"]);
-  assert.deepEqual(negative.input, ["text"]);
-  assert.equal(textModel.input, originalInput);
-  assert.deepEqual(textModel.input, ["text"]);
-
-  const piVision = { ...textModel, input: ["text", "image"] as ("text" | "image")[] };
-  assert.deepEqual(effectiveModelForGeneration(piVision, undefined).input, ["text", "image"]);
 });
 
 test("forwards the chat identity through Pi Agent options into the native stream", () => {

--- a/main/services/generation-runtime.ts
+++ b/main/services/generation-runtime.ts
@@ -19,20 +19,9 @@ export function shouldExposeLocalReasoning(providerId: string): boolean {
   return LOCAL_REASONING_PROVIDER_IDS.has(providerId);
 }
 
-/**
- * Pi's provider serializers use Model.input as the authoritative image gate.
- * Merge only positive trusted metadata into a cloned generation snapshot so
- * legacy vision models and tool screenshots follow the same decision.
- */
-export function effectiveModelForGeneration<TApi extends Api>(
-  model: Model<TApi>,
-  trustedVision: boolean | undefined,
-): Model<TApi> {
-  const supportsImages = model.input.includes("image") || trustedVision === true;
-  return {
-    ...model,
-    input: supportsImages ? ["text", "image"] : ["text"],
-  };
+/** The connection-bound runtime model is the sole request-time image authority. */
+export function runtimeSupportsImages(model: Pick<Model<Api>, "input">): boolean {
+  return model.input.includes("image");
 }
 
 /**

--- a/main/services/llm-client.ts
+++ b/main/services/llm-client.ts
@@ -13,12 +13,11 @@ import { logger } from "../platform.js";
 import { buildAgentTools } from "./tools.js";
 import { APPROVAL_TOOL_NAMES, summarizeToolCall } from "./coding-tools.js";
 import { gitInfo } from "./git.js";
-import { providerModelInfo } from "./provider-model-info.js";
 import { configStore } from "./config-store.js";
 import { chatStore } from "./chat-store.js";
 import {
   buildAgentRuntimeOptions,
-  effectiveModelForGeneration,
+  runtimeSupportsImages,
   settleGenerationCleanup,
   shouldExposeLocalReasoning,
   terminalAssistantReasoningFallback,
@@ -148,11 +147,10 @@ async function prepareGeneration(
   const permission: WorkspacePermission = workspace?.permission ?? "ask";
   const folderPath = workspace?.folderPath;
   const git = folderPath ? await gitInfo(folderPath) : { isRepo: false };
-  // Capability metadata is local: Pi owns Codex facts and the release snapshot
-  // owns legacy-provider facts, so chat startup never waits on a public catalog.
-  const modelInfo = await providerModelInfo.info(runtime.provider.id, params.model);
-  const model = effectiveModelForGeneration(runtime.model, modelInfo.vision);
-  const supportsImages = model.input.includes("image");
+  // The resolved runtime model is the connection-bound capability authority.
+  // Display metadata must not re-enable an input that Pi or discovery rejected.
+  const model = runtime.model;
+  const supportsImages = runtimeSupportsImages(model);
   const settings = await configStore.getSettings();
   const chat = settings.computerUseEnabled ? await chatStore.get(params.chatId) : null;
   let computerUse: ComputerUseController | undefined;

--- a/main/services/model-runtime-core.test.ts
+++ b/main/services/model-runtime-core.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { Api, Model, ProviderStreams } from "@earendil-works/pi-ai";
 
 import { resolveModelRuntimeWith, type ModelRuntimeDependencies } from "./model-runtime-core.js";
+import { CONSERVATIVE_RUNTIME_LIMITS, type RuntimeModelLimits } from "./models-catalog-core.js";
 import type { StoredProvider } from "./types.js";
 
 const codexModel: Model<Api> = {
@@ -25,10 +26,12 @@ const codexStream = (() => {
 function dependencies(options?: {
   provider?: StoredProvider;
   key?: string | null;
+  limits?: RuntimeModelLimits;
 }): ModelRuntimeDependencies {
   return {
     getProvider: async () => options?.provider,
     getApiKey: async () => options?.key ?? null,
+    resolveRuntimeLimits: async () => options?.limits ?? CONSERVATIVE_RUNTIME_LIMITS,
     codex: {
       prepareRuntimeModel: async (modelId) => {
         assert.equal(modelId, codexModel.id);
@@ -58,12 +61,7 @@ test("routes Codex through Pi without consulting API-key providers", async () =>
   };
   const controller = new AbortController();
 
-  const runtime = await resolveModelRuntimeWith(
-    deps,
-    "openai-codex",
-    "gpt-5.4",
-    controller.signal,
-  );
+  const runtime = await resolveModelRuntimeWith(deps, "openai-codex", "gpt-5.4", controller.signal);
   assert.equal(legacyReads, 0);
   assert.strictEqual(receivedSignal, controller.signal);
   assert.strictEqual(runtime.model, codexModel);
@@ -93,6 +91,44 @@ test("keeps the legacy API-key runtime contract unchanged", async () => {
   assert.equal(runtime.model.baseUrl, provider.baseUrl);
   assert.equal(runtime.apiKey, "saved-key");
   assert.equal(runtime.headers, undefined);
+});
+
+test("applies catalog-driven limits without changing the legacy provider transport", async () => {
+  const provider: StoredProvider = {
+    id: "gemini",
+    kind: "openai",
+    label: "Google Gemini",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+    models: ["gemini-2.5-pro"],
+    needsKey: true,
+    isPreset: true,
+  };
+  const limits: RuntimeModelLimits = {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+    input: ["text", "image"],
+  };
+  let receivedProvider: StoredProvider | undefined;
+  let receivedModelId: string | undefined;
+  const deps = dependencies({ provider, key: "saved-key", limits });
+  deps.resolveRuntimeLimits = async (candidate, modelId) => {
+    receivedProvider = candidate;
+    receivedModelId = modelId;
+    return limits;
+  };
+
+  const runtime = await resolveModelRuntimeWith(deps, provider.id, "gemini-2.5-pro");
+
+  assert.strictEqual(receivedProvider, provider);
+  assert.equal(receivedModelId, "gemini-2.5-pro");
+  assert.equal(runtime.model.api, "openai-completions");
+  assert.equal(runtime.model.provider, "gemini");
+  assert.equal(runtime.model.baseUrl, provider.baseUrl);
+  assert.equal(runtime.model.contextWindow, 1_048_576);
+  assert.equal(runtime.model.maxTokens, 65_536);
+  assert.equal(runtime.model.reasoning, true);
+  assert.deepEqual(runtime.model.input, ["text", "image"]);
 });
 
 test("keeps missing legacy API keys on the existing actionable error path", async () => {

--- a/main/services/model-runtime-core.ts
+++ b/main/services/model-runtime-core.ts
@@ -10,6 +10,7 @@ import {
   resolveRuntimeBaseUrl,
   resolveRuntimeHeaders,
 } from "./generation-runtime.js";
+import type { RuntimeModelLimits } from "./models-catalog-core.js";
 import type { StoredProvider } from "./types.js";
 
 const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
@@ -34,18 +35,22 @@ function apiFor(provider: StoredProvider): Api {
   return provider.kind === "anthropic" ? "anthropic-messages" : "openai-completions";
 }
 
-function buildModel(provider: StoredProvider, modelId: string): Model<Api> {
+function buildModel(
+  provider: StoredProvider,
+  modelId: string,
+  limits: RuntimeModelLimits,
+): Model<Api> {
   return {
     id: modelId,
     name: modelId,
     api: apiFor(provider),
     provider: provider.id,
     baseUrl: resolveRuntimeBaseUrl(provider),
-    reasoning: false,
-    input: ["text"],
+    reasoning: limits.reasoning,
+    input: limits.input,
     cost: ZERO_COST,
-    contextWindow: 128_000,
-    maxTokens: 8192,
+    contextWindow: limits.contextWindow,
+    maxTokens: limits.maxTokens,
   };
 }
 
@@ -60,6 +65,7 @@ export interface ResolvedModelRuntime {
 export interface ModelRuntimeDependencies {
   getProvider(providerId: string): Promise<StoredProvider | undefined>;
   getApiKey(providerId: string): Promise<string | null>;
+  resolveRuntimeLimits(provider: StoredProvider, modelId: string): Promise<RuntimeModelLimits>;
   codex: {
     prepareRuntimeModel(modelId: string, signal?: AbortSignal): Promise<Model<Api>>;
     streamSimple: ProviderStreams["streamSimple"];
@@ -98,7 +104,8 @@ export async function resolveModelRuntimeWith(
     throw new Error(`No API key set for ${provider.label}. Add one in Settings → Providers.`);
   }
 
-  const model = buildModel(provider, modelId);
+  const limits = await dependencies.resolveRuntimeLimits(provider, modelId);
+  const model = buildModel(provider, modelId, limits);
   return {
     provider,
     model,

--- a/main/services/model-runtime.ts
+++ b/main/services/model-runtime.ts
@@ -2,6 +2,8 @@
 
 import { configStore } from "./config-store.js";
 import { resolveModelRuntimeWith, type ResolvedModelRuntime } from "./model-runtime-core.js";
+import { catalogProviderSlug } from "./models-catalog-core.js";
+import { modelsCatalog } from "./models-catalog.js";
 import { providerRegistry } from "./provider-registry.js";
 import { secrets } from "./secrets.js";
 
@@ -16,6 +18,11 @@ export function resolveModelRuntime(
     {
       getProvider: (id) => configStore.getProvider(id),
       getApiKey: (id) => secrets.getKey(id),
+      resolveRuntimeLimits: (provider, id) => {
+        const piProviderId = catalogProviderSlug(provider.id);
+        const exact = piProviderId ? providerRegistry.models.getModel(piProviderId, id) : undefined;
+        return modelsCatalog.runtimeLimits(provider, id, exact);
+      },
       codex: providerRegistry.codex,
     },
     providerId,

--- a/main/services/models-catalog-core.ts
+++ b/main/services/models-catalog-core.ts
@@ -27,6 +27,51 @@ interface RawProvider {
 
 export type ModelCatalog = Record<string, RawProvider>;
 export type ModelCatalogProvider = Pick<StoredProvider, "id" | "baseUrl" | "modelMetadata">;
+export type RuntimeCatalogProvider = Pick<
+  StoredProvider,
+  "id" | "kind" | "baseUrl" | "modelMetadata"
+>;
+
+export interface RuntimeModelMetadata {
+  contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: readonly string[];
+}
+
+export interface RuntimeModelLimits {
+  contextWindow: number;
+  maxTokens: number;
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+}
+
+export const CONSERVATIVE_RUNTIME_LIMITS: RuntimeModelLimits = {
+  contextWindow: 128_000,
+  maxTokens: 8_192,
+  reasoning: false,
+  input: ["text"],
+};
+
+export function createModelCatalogLoader(
+  load: () => Promise<unknown>,
+  onError: (error: unknown) => void = () => {},
+): () => Promise<ModelCatalog> {
+  let snapshot: Promise<ModelCatalog> | null = null;
+  return () => {
+    snapshot ??= load()
+      .then(parseModelCatalog)
+      .catch((error: unknown) => {
+        try {
+          onError(error);
+        } catch {
+          // Diagnostics cannot turn a safe catalog fallback into a chat failure.
+        }
+        return {};
+      });
+    return snapshot;
+  };
+}
 
 function rawRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -125,8 +170,10 @@ const PROVIDER_SLUG: Record<string, string> = {
   "openai-codex": "openai",
   anthropic: "anthropic",
   gemini: "google",
+  google: "google",
   deepseek: "deepseek",
   moonshot: "moonshotai",
+  moonshotai: "moonshotai",
 };
 
 const ARTIFICIAL_ANALYSIS_CREATOR: Record<string, string> = {
@@ -138,6 +185,11 @@ const ARTIFICIAL_ANALYSIS_CREATOR: Record<string, string> = {
   moonshot: "Moonshot AI",
 };
 
+/** Map Aiden's stored provider IDs to the shared Pi/models.dev provider IDs. */
+export function catalogProviderSlug(providerId: string): string | undefined {
+  return PROVIDER_SLUG[providerId];
+}
+
 function normalizeId(id: string): string {
   const slash = id.lastIndexOf("/");
   return (slash >= 0 ? id.slice(slash + 1) : id).toLocaleLowerCase();
@@ -147,11 +199,26 @@ function entries(provider: RawProvider | undefined): Array<[string, RawModel]> {
   return provider?.models ? Object.entries(provider.models) : [];
 }
 
+function findRawForProvider(
+  catalog: ModelCatalog,
+  providerId: string,
+  modelId: string,
+): RawModel | null {
+  const provider = catalog[catalogProviderSlug(providerId) ?? ""];
+  if (!provider) return null;
+
+  const exact = modelId.toLocaleLowerCase();
+  const normalized = normalizeId(modelId);
+  const exactMatch = entries(provider).find(([key]) => key.toLocaleLowerCase() === exact);
+  if (exactMatch) return exactMatch[1];
+  return entries(provider).find(([key]) => normalizeId(key) === normalized)?.[1] ?? null;
+}
+
 /** Exact matches across the catalog must win before any lossy normalized match. */
 function findRaw(catalog: ModelCatalog, providerId: string, modelId: string): RawModel | null {
   const exact = modelId.toLocaleLowerCase();
   const normalized = normalizeId(modelId);
-  const preferred = catalog[PROVIDER_SLUG[providerId] ?? ""];
+  const preferred = catalog[catalogProviderSlug(providerId) ?? ""];
 
   const preferredExact = entries(preferred).find(([key]) => key.toLocaleLowerCase() === exact);
   if (preferredExact) return preferredExact[1];
@@ -204,6 +271,110 @@ export function lookupCatalogModelInfo(
   modelId: string,
 ): ModelInfo {
   return modelsDevInfo(catalog, providerId, modelId);
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  const integer = Math.floor(value);
+  return integer > 0 ? integer : undefined;
+}
+
+function supportsImage(input: readonly string[] | undefined): boolean | undefined {
+  return input === undefined ? undefined : input.includes("image");
+}
+
+/**
+ * Resolve request-time limits without public-catalog or device-cache access.
+ *
+ * Each field uses exact Pi metadata first, then the provider-scoped bundled
+ * models.dev snapshot, then the conservative legacy fallback.
+ */
+export function resolveRuntimeLimits(
+  catalog: ModelCatalog,
+  providerId: string,
+  modelId: string,
+  exact?: RuntimeModelMetadata,
+): RuntimeModelLimits {
+  const bundled = findRawForProvider(catalog, providerId, modelId);
+  const bundledInputs = bundled?.modalities?.input;
+  const bundledVision =
+    bundled === null
+      ? undefined
+      : bundled.attachment === true || supportsImage(bundledInputs) === true
+        ? true
+        : bundled.attachment === false || bundledInputs !== undefined
+          ? false
+          : undefined;
+  const exactVision = supportsImage(exact?.input);
+  const vision = exactVision ?? bundledVision ?? false;
+
+  return {
+    contextWindow:
+      positiveInteger(exact?.contextWindow) ??
+      positiveInteger(bundled?.limit?.context) ??
+      CONSERVATIVE_RUNTIME_LIMITS.contextWindow,
+    maxTokens:
+      positiveInteger(exact?.maxTokens) ??
+      positiveInteger(bundled?.limit?.output) ??
+      CONSERVATIVE_RUNTIME_LIMITS.maxTokens,
+    reasoning:
+      exact?.reasoning ??
+      (typeof bundled?.reasoning === "boolean"
+        ? bundled.reasoning
+        : CONSERVATIVE_RUNTIME_LIMITS.reasoning),
+    input: vision ? ["text", "image"] : ["text"],
+  };
+}
+
+function discoveredRuntimeMetadata(
+  provider: RuntimeCatalogProvider,
+  modelId: string,
+): RuntimeModelMetadata | undefined {
+  const metadata = provider.modelMetadata?.[modelId];
+  if (!metadata) return undefined;
+  return {
+    contextWindow: metadata.contextLength,
+    reasoning: metadata.reasoning,
+    input:
+      metadata.vision === undefined ? undefined : metadata.vision ? ["text", "image"] : ["text"],
+  };
+}
+
+function mergeRuntimeMetadata(
+  primary: RuntimeModelMetadata | undefined,
+  fallback: RuntimeModelMetadata | undefined,
+): RuntimeModelMetadata | undefined {
+  if (!primary) return fallback;
+  if (!fallback) return primary;
+  return {
+    contextWindow: primary.contextWindow ?? fallback.contextWindow,
+    maxTokens: primary.maxTokens ?? fallback.maxTokens,
+    reasoning: primary.reasoning ?? fallback.reasoning,
+    input: primary.input ?? fallback.input,
+  };
+}
+
+/**
+ * Follow Pi's provider composition semantics for request-time metadata.
+ *
+ * Built-in provider metadata survives a proxy/base-URL override, while
+ * connection-discovered fields act like per-model overrides. Unrelated custom
+ * provider IDs cannot borrow another provider's catalog entry.
+ */
+export function resolveProviderRuntimeLimits(
+  catalog: ModelCatalog,
+  provider: RuntimeCatalogProvider,
+  modelId: string,
+  piExact?: RuntimeModelMetadata,
+): RuntimeModelLimits {
+  const runtimeSlug = catalogProviderSlug(provider.id);
+  const discovered = discoveredRuntimeMetadata(provider, modelId);
+  return resolveRuntimeLimits(
+    catalog,
+    runtimeSlug ? provider.id : "",
+    modelId,
+    runtimeSlug ? mergeRuntimeMetadata(discovered, piExact) : discovered,
+  );
 }
 
 function isLocalProvider(provider: ModelCatalogProvider): boolean {

--- a/main/services/models-catalog.ts
+++ b/main/services/models-catalog.ts
@@ -11,33 +11,32 @@ import {
 } from "./artificial-analysis-catalog-core.js";
 import { artificialAnalysisRuntime } from "./artificial-analysis-runtime.js";
 import {
-  parseModelCatalog,
+  createModelCatalogLoader,
   resolveModelInfo,
-  type ModelCatalog,
+  resolveProviderRuntimeLimits,
   type ModelCatalogProvider,
+  type RuntimeCatalogProvider,
+  type RuntimeModelMetadata,
 } from "./models-catalog-core.js";
 import type { ModelInfo } from "./types.js";
 
 const BUNDLED_MODELS_DEV_PARTS = ["resources", "model-capabilities.json"] as const;
 
-let modelsDevSnapshot: Promise<ModelCatalog> | null = null;
-
 function bundledPath(parts: readonly string[]): string {
   return join(app.getAppPath(), ...parts);
 }
 
-async function loadModelsDev(): Promise<ModelCatalog> {
-  const path = bundledPath(BUNDLED_MODELS_DEV_PARTS);
-  try {
-    return parseModelCatalog(JSON.parse(await readFile(path, "utf8")));
-  } catch (error) {
+const getModelsDev = createModelCatalogLoader(
+  async () => {
+    const path = bundledPath(BUNDLED_MODELS_DEV_PARTS);
+    return JSON.parse(await readFile(path, "utf8")) as unknown;
+  },
+  (error) => {
     logger.warn("models-catalog", "Could not read bundled model capability catalog.", {
-      path,
       error: error instanceof Error ? error.message : String(error),
     });
-    return {};
-  }
-}
+  },
+);
 
 async function loadArtificialAnalysis(): Promise<ArtificialAnalysisCatalog> {
   try {
@@ -51,12 +50,16 @@ async function loadArtificialAnalysis(): Promise<ArtificialAnalysisCatalog> {
   return EMPTY_ARTIFICIAL_ANALYSIS_CATALOG;
 }
 
-function getModelsDev(): Promise<ModelCatalog> {
-  modelsDevSnapshot ??= loadModelsDev();
-  return modelsDevSnapshot;
-}
-
 export const modelsCatalog = {
+  /** Request-time model limits from Pi-exact metadata and the bundled offline snapshot only. */
+  async runtimeLimits(
+    provider: RuntimeCatalogProvider,
+    modelId: string,
+    exact?: RuntimeModelMetadata,
+  ) {
+    return resolveProviderRuntimeLimits(await getModelsDev(), provider, modelId, exact);
+  },
+
   /** Capability info for one model. */
   async info(provider: ModelCatalogProvider, modelId: string): Promise<ModelInfo> {
     const [modelsDev, artificialAnalysis] = await Promise.all([

--- a/main/services/models.test.ts
+++ b/main/services/models.test.ts
@@ -3,9 +3,13 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import type { ArtificialAnalysisCatalog } from "./artificial-analysis-catalog-core.js";
 import {
+  CONSERVATIVE_RUNTIME_LIMITS,
+  createModelCatalogLoader,
   lookupCatalogModelInfo,
   parseModelCatalog,
   resolveModelInfo,
+  resolveProviderRuntimeLimits,
+  resolveRuntimeLimits,
 } from "./models-catalog-core.js";
 import { normalizeProviderBaseUrl, testConnection } from "./models.js";
 
@@ -260,6 +264,218 @@ test("models.dev lookups retain unknown flags for unmatched model ids", () => {
   });
 });
 
+test("runtime limits use provider-scoped bundled metadata with conservative partial fallbacks", () => {
+  const catalog = parseModelCatalog({
+    google: {
+      models: {
+        "gemini-2.5-pro": {
+          name: "Gemini 2.5 Pro",
+          attachment: true,
+          reasoning: true,
+          modalities: { input: ["text", "image", "audio"] },
+          limit: { context: 1_048_576, output: 65_536 },
+        },
+        "gemini-partial": {
+          name: "Gemini Partial",
+          reasoning: true,
+          modalities: { input: ["text"] },
+          limit: { context: 256_000 },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(resolveRuntimeLimits(catalog, "gemini", "gemini-2.5-pro"), {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+    input: ["text", "image"],
+  });
+  assert.deepEqual(resolveRuntimeLimits(catalog, "gemini", "gemini-partial"), {
+    contextWindow: 256_000,
+    maxTokens: 8_192,
+    reasoning: true,
+    input: ["text"],
+  });
+  assert.deepEqual(
+    resolveRuntimeLimits(catalog, "custom-openai", "gemini-2.5-pro"),
+    CONSERVATIVE_RUNTIME_LIMITS,
+  );
+  assert.deepEqual(
+    resolveRuntimeLimits(catalog, "gemini", "missing-model"),
+    CONSERVATIVE_RUNTIME_LIMITS,
+  );
+});
+
+test("exact Pi metadata wins field by field over bundled runtime metadata", () => {
+  const catalog = parseModelCatalog({
+    google: {
+      models: {
+        "gemini-exact": {
+          name: "Gemini Exact",
+          attachment: true,
+          reasoning: true,
+          limit: { context: 1_000_000, output: 64_000 },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(
+    resolveRuntimeLimits(catalog, "gemini", "gemini-exact", {
+      contextWindow: 2_000_000,
+      reasoning: false,
+      input: ["text"],
+    }),
+    {
+      contextWindow: 2_000_000,
+      maxTokens: 64_000,
+      reasoning: false,
+      input: ["text"],
+    },
+  );
+});
+
+test("provider-scoped Pi metadata survives proxy routing with discovered overrides", () => {
+  const catalog = parseModelCatalog({
+    google: {
+      models: {
+        "gemini-2.5-pro": {
+          name: "Gemini 2.5 Pro",
+          attachment: true,
+          reasoning: true,
+          limit: { context: 1_048_576, output: 65_536 },
+        },
+      },
+    },
+  });
+  const canonical = {
+    id: "gemini",
+    kind: "openai" as const,
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+  };
+  const edited = {
+    ...canonical,
+    baseUrl: "https://models.example.test/v1",
+    modelMetadata: {
+      "gemini-2.5-pro": {
+        source: "provider" as const,
+        vision: false,
+        reasoning: false,
+        contextLength: 16_384,
+      },
+    },
+  };
+  const piExact = {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+    input: ["text", "image"],
+  };
+
+  assert.deepEqual(
+    resolveProviderRuntimeLimits(catalog, canonical, "gemini-2.5-pro", {
+      ...piExact,
+      input: ["text"],
+    }),
+    {
+      contextWindow: 1_048_576,
+      maxTokens: 65_536,
+      reasoning: true,
+      input: ["text"],
+    },
+  );
+  assert.deepEqual(resolveProviderRuntimeLimits(catalog, edited, "gemini-2.5-pro", piExact), {
+    contextWindow: 16_384,
+    maxTokens: 65_536,
+    reasoning: false,
+    input: ["text"],
+  });
+  assert.deepEqual(
+    resolveProviderRuntimeLimits(
+      catalog,
+      {
+        id: "custom-openai",
+        kind: "openai",
+        baseUrl: "https://models.example.test/v1",
+      },
+      "gemini-2.5-pro",
+      piExact,
+    ),
+    CONSERVATIVE_RUNTIME_LIMITS,
+  );
+});
+
+test("connection-bound discovery enables local vision without trusting a colliding catalog id", () => {
+  const catalog = parseModelCatalog({
+    google: {
+      models: {
+        "gemini-2.5-pro": {
+          name: "Gemini 2.5 Pro",
+          attachment: false,
+          reasoning: false,
+          limit: { context: 1_048_576, output: 65_536 },
+        },
+      },
+    },
+  });
+  const local = {
+    id: "lmstudio",
+    kind: "openai" as const,
+    baseUrl: "http://localhost:1234/v1",
+    modelMetadata: {
+      "gemini-2.5-pro": {
+        source: "lmstudio" as const,
+        vision: true,
+        reasoning: true,
+        contextLength: 32_768,
+      },
+    },
+  };
+
+  assert.deepEqual(resolveProviderRuntimeLimits(catalog, local, "gemini-2.5-pro"), {
+    contextWindow: 32_768,
+    maxTokens: 8_192,
+    reasoning: true,
+    input: ["text", "image"],
+  });
+});
+
+test("bundled catalog loader fails closed and shares one concurrent load", async () => {
+  let attempts = 0;
+  const errors: unknown[] = [];
+  const missing = createModelCatalogLoader(async () => {
+    attempts += 1;
+    throw Object.assign(new Error("missing"), { code: "ENOENT" });
+  }, errors.push.bind(errors));
+
+  const [first, second, third] = await Promise.all([missing(), missing(), missing()]);
+  assert.deepEqual(first, {});
+  assert.strictEqual(second, first);
+  assert.strictEqual(third, first);
+  assert.equal(attempts, 1);
+  assert.equal(errors.length, 1);
+  assert.deepEqual(
+    resolveRuntimeLimits(first, "gemini", "gemini-2.5-pro"),
+    CONSERVATIVE_RUNTIME_LIMITS,
+  );
+
+  const malformed = createModelCatalogLoader(async () => ({
+    google: { models: { broken: { name: "", limit: { context: "many" } } } },
+  }));
+  assert.deepEqual(await malformed(), {});
+
+  const throwingDiagnostic = createModelCatalogLoader(
+    async () => {
+      throw new Error("unavailable");
+    },
+    () => {
+      throw new Error("diagnostic failed");
+    },
+  );
+  assert.deepEqual(await throwingDiagnostic(), {});
+});
+
 test("local discovery metadata takes precedence over catalog metadata", () => {
   const catalog = parseModelCatalog({
     google: {
@@ -388,6 +604,12 @@ test("runtime metadata stays offline and only models.dev data is packaged", asyn
     Object.values(provider.models ?? {}).filter((model) => Boolean(model.name?.trim())),
   );
   assert.ok(namedModels.length > 0, "the release snapshot should include model display names");
+  assert.deepEqual(resolveRuntimeLimits(catalog, "gemini", "gemini-2.5-pro"), {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+    input: ["text", "image"],
+  });
 
   await assert.rejects(
     readFile(new URL("../../resources/artificial-analysis-models.json", import.meta.url), "utf8"),


### PR DESCRIPTION
## Summary
- resolve non-Codex runtime limits from connection-discovered overrides, provider-scoped Pi models, the packaged models.dev snapshot, and conservative fallbacks
- make the resolved runtime model the sole image-capability gate for generation and chat titles
- harden the packaged catalog loader so it is shared, offline, and fail-closed

## Why
Legacy non-Codex runtime models were hardcoded as text-only with a 128K context window, 8K output limit, and no reasoning. That throttled models such as Gemini 2.5 Pro despite Pi and Aiden's packaged catalog already carrying better capability metadata.

This follows Pi's built-in-provider behavior: provider-owned model metadata survives proxy base-URL routing, connection-discovered model fields act as overrides, and unrelated custom providers cannot borrow another provider's model metadata. The existing OpenAI-compatible Gemini transport is deliberately unchanged; native Google transport remains Phase 1.

## Validation
- `npm run type-check`
- `npm run lint`
- `npm test` — 629 TypeScript/JavaScript tests and 41 Rust tests
- `npm run build`
- two fresh independent adversarial review passes, both clean after fixes