### PR TITLE
docs: add Homebrew install and generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,9 @@ jobs:
           shasum -a 256 -- *.dmg *.zip latest-mac.yml > SHA256SUMS
           gh release create "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
             --title "Aiden Agent $RELEASE_VERSION" \
-            --notes "Automated verified Aiden Agent beta release." \
+            --notes "Aiden Agent beta release. Changes since the previous release:" \
+            --generate-notes \
             --latest \
             -- *.dmg *.zip latest-mac.yml SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
   A native-feeling macOS workspace for chatting with local or hosted AI models and safely working inside the folders you choose.
 </p>
 
+```sh
+brew install --cask sambitcreate/tap/aiden-agent
+```
+
 ![Aiden Agent showing a workspace chat and Personal Model Pad](docs/assets/aiden-agent-app.png)
 
 ## Why Aiden

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,7 +22,8 @@ visitors and installed apps can download GitHub Release assets without a GitHub 
   native helpers, signs with Developer ID, notarizes, staples, and verifies the app, DMG, and ZIP.
 - Automatic-update builds also generate `latest-mac.yml`. The workflow publishes that file and
   the exact verified DMG/ZIP pair together, plus `SHA256SUMS`, in one public GitHub release in
-  this repository. The DMG is the website download; the ZIP and YAML are the updater payload.
+  this repository. Each release includes GitHub-generated notes for changes since the previous
+  release. The DMG is the website download; the ZIP and YAML are the updater payload.
 - Aiden checks shortly after launch and every six hours. It downloads a newer signed update in
   the background, notifies the user when ready, and installs only after Aiden exits normally.
   It never interrupts an open workspace or bypasses the existing quit barriers.


### PR DESCRIPTION
## What changed

- add the public Homebrew cask install command below the README introduction
- skip DMG releases for Markdown, documentation, and release-workflow-only pushes
- generate GitHub release notes from changes since the previous release
- bind each release tag to the exact workflow commit

## Impact

Documentation-only maintenance no longer creates a new signed DMG. Future source releases include a useful GitHub changelog while the in-app updater remains unchanged.

## Validation

- release workflow YAML parsed successfully
- `git diff --check` passed
- Homebrew cask availability was verified
- GitHub release-notes API preview succeeded