### PR TITLE
Add a Nix dev shell so Node and Rust match CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# `use flake` only watches flake.nix and flake.lock, but flake.nix also reads
+# the pinned Rust toolchain, so watch that too or the shell goes stale.
+watch_file native/computer-use-broker/rust-toolchain.toml
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 release/
 native/computer-use-broker/target/
 
+# Nix development shell (flake.nix and flake.lock stay versioned)
+.direnv/
+
 # Agent context (auto-generated, not worth versioning)
 .claude/
 .agents/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Core technologies include Electron 43, React 19, TypeScript, Vite, Tailwind CSS,
 - A full Xcode 26 or newer for the Apple Foundation Models helper
 - An Apple Development or Developer ID Application identity for packaged builds
 
+Node and Rust can come from the checked-in **Nix** flake instead, which pins both to the versions CI uses and reads the Cargo toolchain straight from `native/computer-use-broker/rust-toolchain.toml`. Xcode and the signing identities always come from the host.
+
+```bash
+nix develop
+```
+
+Run `direnv allow` once instead to have the shell load automatically on `cd`.
+
 ### Run locally
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785820796,
+        "narHash": "sha256-sZXy8mzUMi2cOGulhoW4HWAZB6JhXOAx1x8J4auZFWk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b6916ba032e02122d6ed3064f40cabe937363d43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Development environment for Aiden Agent";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { nixpkgs, rust-overlay, ... }:
+    let
+      # macOS only: the Apple Foundation Models helper targets macOS 26 and
+      # packaging runs through `electron-builder --mac`.
+      forAllSystems = nixpkgs.lib.genAttrs [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              # package.json requires >=22.19; CI runs 22.22.3.
+              pkgs.nodejs_22
+
+              # Read the file cargo and rustup already read, so the pinned
+              # toolchain cannot drift from this shell. `npm test` runs
+              # `cargo clippy --locked -- -D warnings`, which is sensitive to
+              # the exact release.
+              (pkgs.rust-bin.fromRustupToolchainFile ./native/computer-use-broker/rust-toolchain.toml)
+            ];
+
+            # DEVELOPER_DIR, SDKROOT, CC and CXX are deliberately unset: the
+            # Swift helper builds against Apple's SDK and signing identities
+            # live in the login keychain, so both come from the host Xcode.
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Today each contributor installs Node and Rust by hand, so no two machines match. On my Mac, Homebrew had given me cargo 1.92.0. This repo asks for 1.96.1 — that number lives in `native/computer-use-broker/rust-toolchain.toml`, the file rustup reads to decide which Rust version to use. The gap matters because `npm test` eventually runs `cargo clippy --locked -- -D warnings`. In plain words, that command runs Clippy (the Rust linter), forces it to use exactly the dependency versions recorded in `Cargo.lock` instead of picking newer ones (`--locked`), and turns every warning into a hard failure (`-D warnings`). Clippy adds new lints in almost every Rust release, so a newer Clippy rejects code an older one accepted. The result is that a change can pass on my machine and fail CI, or pass CI and then break for the next contributor. It reads like a code bug, but it is a version bug — and you are the one who ends up working that out during review.

This PR adds a Nix dev shell. Nix is a package manager that installs exact, pinned versions of tools into a temporary shell, without changing anything else on your Mac. A contributor runs one command, `nix develop`, and lands in a shell holding the same tools CI uses: npm 10.9.8 and cargo 1.96.1, both exact matches. The detail that matters for you is that `flake.nix` never writes the Rust version down a second time. It calls `rust-bin.fromRustupToolchainFile` and hands it the path to your existing `rust-toolchain.toml`, so Nix reads the version out of the file you already maintain. Bump that file and the shell follows on its own — there is no second copy to forget. Xcode and your signing identities deliberately still come from the Mac, because the Swift helper builds against Apple's real SDK and Apple does not permit Nix to redistribute it. Nothing that exists today changes: no CI edits, no new scripts, 115 lines added and none modified. It is entirely opt-in, so if you never run `nix develop`, your setup behaves exactly as it does now.

**What each file does**

- `flake.nix` — declares the shell: Node 22 (your `engines` field asks for >=22.19), plus Rust read from your `rust-toolchain.toml`. It deliberately leaves `DEVELOPER_DIR`, `SDKROOT`, `CC`, and `CXX` unset so the host Xcode keeps driving every native build.
- `flake.lock` — records the exact nixpkgs and rust-overlay commits used, so two contributors resolve to byte-identical tool builds rather than "whatever was current that day".
- `.envrc` — optional. If you use direnv, the shell loads automatically when you `cd` into the repo. It also watches `rust-toolchain.toml`, because direnv otherwise only notices changes to `flake.nix` and would leave you in a stale shell after a toolchain bump.
- `.gitignore` — one entry, `.direnv/`, the local cache direnv writes.
- `README.md` — documents `nix develop` beneath the existing Requirements list.

**Verified on macOS (aarch64):** `nix flake check`, `npm ci`, `npm run type-check`, `npm run lint`, and `npm run test:computer-use:native` (the fmt + test + Clippy gate) all pass inside the shell.

**One known gap, flagged honestly:** Node resolves to 22.23.2 while CI pins 22.22.3. Both satisfy the `>=22.19` requirement in `package.json`, and npm matches exactly at 10.9.8 because both Node versions bundle it. I chose not to force the exact patch, because pinning it needs a hand-written override that stops tracking nixpkgs and becomes the very maintenance burden this PR is trying to remove. Happy to change that if you would rather have it exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
