### PR TITLE
Harden macOS updates, microphone access, and Computer Use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           set -euo pipefail
           test -n "$GH_TOKEN"
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists; refusing to replace published update assets." >&2
+            echo "Release or draft $RELEASE_TAG already exists; refusing to replace update assets." >&2
             exit 1
           fi
           cd release/distribution
@@ -109,5 +109,9 @@ jobs:
             --title "Aiden Agent $RELEASE_VERSION" \
             --notes "Aiden Agent beta release. Changes since the previous release:" \
             --generate-notes \
-            --latest \
+            --draft \
             -- *.dmg *.zip latest-mac.yml SHA256SUMS
+          gh release edit "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false \
+            --latest

--- a/docs/computer-use-integration.md
+++ b/docs/computer-use-integration.md
@@ -158,7 +158,10 @@ Use unavailable.
 2. **Agent adapter:** the consolidated Hermes-compatible schema; capture and
    all action mappings; image/structured result normalization; capability and
    stale-element-token handling; action-aware approvals; model capability
-   gating; cancellation and exact-target `capture_after`.
+   gating; cancellation and exact-target `capture_after`. Coordinate fields use
+   homogeneous numeric arrays bounded to exactly two items so OpenAI-compatible
+   providers receive object-valued JSON Schema `items`; runtime validation still
+   independently requires two finite nonnegative values.
 3. **Product surface:** persisted global enablement and per-chat activation;
    readiness/doctor/permission IPC; Settings and composer controls; accessible
    allow-once approval details; lifecycle cleanup.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -16,6 +16,7 @@ This directory is the source of truth for Aiden's implementation plans. The engi
 | [Slash Commands and Skill Invocation](slash-commands-and-skill-invocation-plan.md)          | Planned | Pi command, Aiden architecture, and composer UI audits are complete; implementation has not started.                                                                         |
 | [Subagent Orchestration Expansion](subagent-orchestration-expansion-plan.md)                | Active  | Phases 0–6, Phase 7A durable lifecycle, and the canonical Phase 7B1 storage seam are complete; app-lifetime coordinator activation is next.                                |
 | [Taracodlab Learnings](taracodlab-learnings-plan.md)                                        | Partial | Phases A–B and D, plus core Phase E, are implemented; the remaining roadmap is open.                                                                                         |
+| [Update, Microphone, and Computer Use Hardening](update-microphone-computer-use-hardening-plan.md) | Partial | Root causes, code fixes, and automated gates are complete; installed 0.27.0 → next-release and clean-TCC signed-package acceptance remain.                                  |
 
 ## Completed
 

--- a/docs/plans/update-microphone-computer-use-hardening-plan.md
+++ b/docs/plans/update-microphone-computer-use-hardening-plan.md
@@ -1,0 +1,36 @@
+# Update, Microphone, and Computer Use Hardening
+
+Status: Partial
+
+## Goal
+
+Restore automatic updates from the 0.27 beta line, make microphone capture reliable in signed macOS builds, and remove the provider-schema failure blocking Computer Use.
+
+## Phase 1 — Independent triage (complete)
+
+- Confirmed the public `latest-mac.yml` named a ZIP that GitHub did not publish under that name.
+- Confirmed signed app and Renderer helper entitlements omitted macOS audio-input access.
+- Confirmed tuple coordinates emitted array-valued JSON Schema `items`, rejected by Moonshot-flavored validators.
+- Kept missing provider `finish_reason` fail-closed because accepting a truncated stream could make an incomplete tool call actionable.
+
+## Phase 2 — Release and runtime fixes (complete)
+
+- Use stable, space-free macOS ZIP and DMG artifact names.
+- Bind update metadata to one exact version, ZIP basename, and recomputed SHA-512 before release promotion; keep assets draft-only until the complete set uploads.
+- Prevent stale updater-state reads from replacing newer notifications and display only bounded semantic versions.
+- Add audio-input entitlement to the main app and inherited Electron helper entitlements.
+- Verify every signed Electron helper has the exact enabled entitlement set and prepare the development runtime with microphone usage copy.
+- Preserve actionable microphone permission, missing-device, busy-device, and interruption errors.
+- Cancel stale microphone starts and release streams and audio contexts across failures, cancellation, and unmount.
+- Publish coordinate arrays with object-valued `items` plus exact two-item bounds while retaining runtime tuple validation, including rejection of sparse arrays.
+
+## Phase 3 — Automated verification (complete)
+
+- TypeScript, lint, focused updater/signing/microphone/Computer Use tests, and the complete test suite pass.
+- Three independent adversarial reviews and the parent review covered release, permission, lifecycle, and Computer Use security regressions.
+
+## Phase 4 — Release acceptance (pending)
+
+- Publish a new immutable release with the safe manifest/payload pair.
+- From an installed 0.27.0 build, verify download completion, the in-app Update ready banner, protected Update and Restart, and successful relaunch.
+- On a clean macOS TCC profile, verify both composer voice input and global dictation after granting microphone access.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,10 +20,14 @@ visitors and installed apps can download GitHub Release assets without a GitHub 
   checks remain mandatory on a physical Mac during packaged acceptance.
 - `npm run dist` refreshes only the approved release-time model snapshot, builds the app and
   native helpers, signs with Developer ID, notarizes, staples, and verifies the app, DMG, and ZIP.
-- Automatic-update builds also generate `latest-mac.yml`. The workflow publishes that file and
-  the exact verified DMG/ZIP pair together, plus `SHA256SUMS`, in one public GitHub release in
-  this repository. Each release includes GitHub-generated notes for changes since the previous
-  release. The DMG is the website download; the ZIP and YAML are the updater payload.
+- Automatic-update builds also generate `latest-mac.yml`. macOS archive names are restricted to
+  stable GitHub-safe characters, and release verification requires the manifest URL and path to
+  equal the exact ZIP basename. Verification also recomputes the ZIP's SHA-512 digest and requires
+  both the current file entry and legacy top-level manifest field to match it. The workflow
+  publishes that file and the exact verified DMG/ZIP pair together, plus `SHA256SUMS`, in one
+  public GitHub release in this repository. Each release includes GitHub-generated notes for
+  changes since the previous release. The DMG is the website download; the ZIP and YAML are the
+  updater payload.
 - Aiden checks shortly after launch and every six hours. It downloads a newer signed update in
   the background, notifies the user when ready, and installs only after Aiden exits normally.
   It never interrupts an open workspace or bypasses the existing quit barriers.
@@ -83,7 +87,9 @@ its history scan, before changing visibility.
    its scoped `GITHUB_TOKEN` with `contents: write`; no separate release-repository token exists.
 5. Trigger `Release macOS` manually for the first release or push a reviewed commit to `main`.
 6. Install the published DMG, then publish one higher version and verify the installed app
-   downloads it, reports it ready, and installs it after a normal quit.
+   downloads it, reports it ready, and installs it through the in-app Update and Restart action.
+   For the 0.27 recovery release, repeat this from an installed 0.27.0 build because older
+   manifests named payloads that GitHub normalized differently.
 
 Each Aiden beta is a normal published GitHub Release, rather than GitHub's `pre-release` state.
 The updater intentionally uses GitHub's `releases/latest/download` endpoint and the app rejects

--- a/main/services/computer-use/computer-use-tool.test.ts
+++ b/main/services/computer-use/computer-use-tool.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { validateToolArguments } from "@earendil-works/pi-ai";
 import type { CuaDriverToolInfo } from "./contract.js";
 import {
   COMPUTER_USE_DISCOVERY_TIMEOUT_MS,
@@ -422,6 +423,60 @@ test("publishes the consolidated tool as sequential and preserves zero-based ind
     () => normalizeComputerUseArgs({ action: "click", element: -1 }),
     /zero-based non-negative/u,
   );
+});
+
+test("publishes provider-compatible fixed-length coordinate schemas", () => {
+  const { controller } = harness();
+  const tool = createComputerUseAgentTool(controller);
+  const parameters = JSON.parse(JSON.stringify(tool.parameters)) as {
+    properties: Record<string, Record<string, unknown>>;
+  };
+
+  for (const field of ["coordinate", "from_coordinate", "to_coordinate"]) {
+    const property = parameters.properties[field];
+    assert.ok(property);
+    assert.equal(property.type, "array");
+    assert.equal(property.minItems, 2);
+    assert.equal(property.maxItems, 2);
+    assert.equal(Array.isArray(property.items), false);
+    assert.deepEqual(property.items, { type: "number", minimum: 0 });
+  }
+
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if ("items" in record) {
+      assert.ok(record.items && typeof record.items === "object", "items must be an object schema");
+      assert.equal(
+        Array.isArray(record.items),
+        false,
+        "tool schemas must not use tuple-style items",
+      );
+    }
+    for (const nested of Object.values(record)) visit(nested);
+  };
+  visit(parameters);
+
+  const valid = validateToolArguments(tool, {
+    type: "toolCall",
+    id: "coordinate-valid",
+    name: tool.name,
+    arguments: { action: "click", coordinate: [1.5, 2.5] },
+  });
+  assert.deepEqual(valid.coordinate, [1.5, 2.5]);
+
+  for (const coordinate of [[1], [1, 2, 3], [-1, 2], [Number.NaN, 2], [Infinity, 2]]) {
+    assert.throws(
+      () =>
+        validateToolArguments(tool, {
+          type: "toolCall",
+          id: "coordinate-invalid",
+          name: tool.name,
+          arguments: { action: "click", coordinate },
+        }),
+      /Validation failed for tool "computer_use"/u,
+    );
+  }
 });
 
 test("hard-blocks normalized dangerous text and destructive shortcuts before approval", async () => {

--- a/main/services/computer-use/safety.test.ts
+++ b/main/services/computer-use/safety.test.ts
@@ -209,6 +209,46 @@ test("normalizeComputerUseArgs click family: exclusive target + button pinning",
   );
 });
 
+test("normalizeComputerUseArgs rejects adversarial coordinate values on every coordinate path", () => {
+  const sparse = new Array<number>(2);
+  const missingSecond = [1, 2];
+  delete missingSecond[1];
+  const values: unknown[] = [
+    sparse,
+    missingSecond,
+    [1],
+    [1, 2, 3],
+    [-1, 2],
+    [Number.NaN, 2],
+    [Number.POSITIVE_INFINITY, 2],
+    [1, "2"],
+    null,
+  ];
+
+  for (const coordinate of values) {
+    assertSafetyError("invalid_coordinate", () =>
+      normalizeComputerUseArgs({ action: "click", coordinate } as never),
+    );
+    assertSafetyError("invalid_coordinate", () =>
+      normalizeComputerUseArgs({
+        action: "drag",
+        from_coordinate: coordinate,
+        to_coordinate: [3, 4],
+      } as never),
+    );
+    assertSafetyError("invalid_coordinate", () =>
+      normalizeComputerUseArgs({
+        action: "drag",
+        from_coordinate: [1, 2],
+        to_coordinate: coordinate,
+      } as never),
+    );
+    assertSafetyError("invalid_coordinate", () =>
+      normalizeComputerUseArgs({ action: "scroll", direction: "down", coordinate } as never),
+    );
+  }
+});
+
 test("normalizeComputerUseArgs modifiers canonicalization on click", () => {
   // Aliases resolved + sorted by MODIFIER_ORDER = [ctrl, option, shift, cmd, ...].
   // Input order cmd+shift+alt canonicalizes to [option, shift, cmd].

--- a/main/services/computer-use/safety.ts
+++ b/main/services/computer-use/safety.ts
@@ -126,14 +126,16 @@ function own(value: object, key: string): boolean {
 }
 
 function finiteCoordinate(value: unknown, name: string): [number, number] {
+  const hasBothValues =
+    Array.isArray(value) && value.length === 2 && own(value, "0") && own(value, "1");
+  const parts = hasBothValues ? [value[0], value[1]] : [];
   if (
-    !Array.isArray(value) ||
-    value.length !== 2 ||
-    !value.every((part) => typeof part === "number" && Number.isFinite(part) && part >= 0)
+    !hasBothValues ||
+    !parts.every((part) => typeof part === "number" && Number.isFinite(part) && part >= 0)
   ) {
     fail("invalid_coordinate", `${name} must be a two-number non-negative coordinate.`);
   }
-  return [value[0] as number, value[1] as number];
+  return [parts[0] as number, parts[1] as number];
 }
 
 function nonNegativeIndex(value: unknown, name: string): number {

--- a/main/services/computer-use/schema.ts
+++ b/main/services/computer-use/schema.ts
@@ -33,7 +33,12 @@ const Action = Type.Union([
   Type.Literal("list_windows"),
   Type.Literal("focus_app"),
 ]);
-const Coordinate = Type.Tuple([Type.Number({ minimum: 0 }), Type.Number({ minimum: 0 })]);
+// Some OpenAI-compatible providers reject draft-07 tuple schemas because their
+// `items` value is an array. Keep tuple typing for Aiden while publishing the
+// equivalent homogeneous, fixed-length schema those providers accept.
+const Coordinate = Type.Unsafe<[number, number]>(
+  Type.Array(Type.Number({ minimum: 0 }), { minItems: 2, maxItems: 2 }),
+);
 const Modifier = Type.Union(
   [
     "cmd",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint": "eslint .",
     "pretest": "npm run build:worktree-remover && npm run test:onboarding && npm run test:assistant-automations && npm run test:compaction && npm run test:subagents",
     "pretest:coverage": "npm run build:worktree-remover && npm run build:subagent-run-store && npm run test:preflight && npm run test:scheduled && npm run test:google-provider && npm run test:config-recovery && npm run test:command-system && npm run test:compaction && npm run test:subagents",
-    "test:preflight": "npm run test:artificial-analysis && npm run test:model-pad && tsx --test main/services/appearance-preview-core.test.ts main/services/generation-timeline.test.ts main/services/local-runtime-status.test.ts main/services/mcp-tool-result.test.ts renderer/components/activity-feed.test.tsx renderer/components/chat-sidebar.test.tsx renderer/components/composer.test.tsx renderer/main/chat-transition.test.tsx renderer/components/thinking-control.test.tsx renderer/lib/agent-steps.test.ts renderer/lib/dialog-motion-contract.test.ts renderer/lib/pill-appearance.test.ts renderer/lib/streaming-motion-contract.test.ts renderer/lib/streaming-reveal.test.ts renderer/pill-preload-channels.test.ts renderer/shared/anthropic-thinking.test.ts renderer/shared/app-update.test.ts renderer/shared/claim-check.test.ts renderer/shared/codex-thinking.test.ts renderer/shared/google-thinking.test.ts renderer/shared/provider-deployment.test.ts",
+    "test:preflight": "npm run test:artificial-analysis && npm run test:model-pad && tsx --test main/services/appearance-preview-core.test.ts main/services/generation-timeline.test.ts main/services/local-runtime-status.test.ts main/services/mcp-tool-result.test.ts renderer/components/activity-feed.test.tsx renderer/components/chat-sidebar.test.tsx renderer/components/composer.test.tsx renderer/main/chat-transition.test.tsx renderer/components/thinking-control.test.tsx renderer/lib/agent-steps.test.ts renderer/lib/dialog-motion-contract.test.ts renderer/lib/pill-appearance.test.ts renderer/lib/streaming-motion-contract.test.ts renderer/lib/streaming-reveal.test.ts renderer/lib/voice-recorder-core.test.ts renderer/pill-preload-channels.test.ts renderer/shared/anthropic-thinking.test.ts renderer/shared/app-update.test.ts renderer/shared/claim-check.test.ts renderer/shared/codex-thinking.test.ts renderer/shared/google-thinking.test.ts renderer/shared/provider-deployment.test.ts",
     "test:branding": "tsx --test main/runtime-mode.test.ts main/runtime-profile-core.test.ts main/runtime-profile-bootstrap.test.ts main/services/app-updater-core.test.ts && node --test scripts/prepare-ci-release.test.mjs scripts/prepare-macos-dev-runtime.test.mjs",
     "test:scheduled": "tsx --test main/handlers/scheduled-tasks-parse.test.ts main/services/assistant/mcp-tool.test.ts main/services/assistant/tool-loop-guard.test.ts main/services/mcp-selection.test.ts main/services/scheduled-settings-core.test.ts main/services/schedule-guard.test.ts main/services/schedule-notification.test.ts main/services/schedule-service-core.test.ts main/services/schedule-store.test.ts main/services/schedule-script.test.ts main/services/schedule-tool.test.ts renderer/lib/scheduled-task-view.test.ts",
     "test:artificial-analysis": "tsx --test main/services/artificial-analysis-action-core.test.ts main/services/artificial-analysis-cache.test.ts main/services/artificial-analysis-runtime-core.test.ts main/services/artificial-analysis-catalog-core.test.ts main/services/provider-model-info-core.test.ts renderer/lib/artificial-analysis-query-state.test.ts renderer/lib/model-data-control.test.ts renderer/lib/settings-section.test.ts",
@@ -209,11 +209,13 @@
       }
     ],
     "mac": {
+      "artifactName": "Aiden-Agent-${version}-${arch}-mac.${ext}",
       "category": "public.app-category.developer-tools",
       "icon": "resources/app-icon.icns",
       "notarize": true,
       "sign": "./scripts/sign-macos.mjs",
       "entitlements": "resources/entitlements.mac.plist",
+      "entitlementsInherit": "resources/entitlements.mac.inherit.plist",
       "signIgnore": "\\/Contents\\/Helpers\\/CuaDriver\\.app\\/Contents\\/MacOS\\/cua-driver$",
       "binaries": [
         "Contents/Helpers/Aiden Foundation Models Helper.app",
@@ -258,7 +260,7 @@
       }
     },
     "dmg": {
-      "artifactName": "${productName} Beta-${version}-${arch}.${ext}",
+      "artifactName": "Aiden-Agent-Beta-${version}-${arch}.${ext}",
       "background": "resources/dmg-background.png",
       "iconSize": 104,
       "iconTextSize": 12,

--- a/renderer/components/chat-sidebar.test.tsx
+++ b/renderer/components/chat-sidebar.test.tsx
@@ -73,8 +73,26 @@ test("update-ready banner offers Later and a guarded restart action", () => {
   assert.match(banner, /Aiden Agent \{displayedVersion\}/u);
   assert.match(banner, /Restart to finish installing\./u);
   assert.match(banner, />\s*Later\s*</u);
+  assert.match(banner, /Update and restart/u);
   assert.match(banner, /appUpdatesApi\.restart\(\)/u);
   assert.match(banner, /disabled=\{!open \|\| restarting \|\| Boolean\(blockedReason\)\}/u);
+});
+
+test("a stale initial update-state response cannot overwrite a newer notification", () => {
+  const sidebar = source("./chat-sidebar.tsx");
+  const banner = between(
+    sidebar,
+    "function UpdateReadyBanner",
+    "\n}\n\nfunction GeneratedTitleReveal",
+  );
+
+  assert.match(banner, /let notificationRevision = 0;/u);
+  assert.match(banner, /notificationRevision \+= 1;\s+applySnapshot\(next\);/u);
+  assert.match(banner, /const requestedAtRevision = notificationRevision;/u);
+  assert.match(
+    banner,
+    /if \(notificationRevision === requestedAtRevision\) applySnapshot\(next\);/u,
+  );
 });
 
 test("update-ready banner uses the Aiden mark and shared compact-surface motion", () => {

--- a/renderer/components/chat-sidebar.tsx
+++ b/renderer/components/chat-sidebar.tsx
@@ -102,15 +102,22 @@ function UpdateReadyBanner({ blockedReason }: { blockedReason?: string }) {
 
   React.useEffect(() => {
     let cancelled = false;
+    let notificationRevision = 0;
     const applySnapshot = (next: AppUpdateSnapshot) => {
       if (cancelled) return;
       setSnapshot(next);
       setRestarting(false);
     };
-    const unsubscribe = appUpdatesApi.onStateChanged(applySnapshot);
+    const unsubscribe = appUpdatesApi.onStateChanged((next) => {
+      notificationRevision += 1;
+      applySnapshot(next);
+    });
+    const requestedAtRevision = notificationRevision;
     void appUpdatesApi
       .state()
-      .then(applySnapshot)
+      .then((next) => {
+        if (notificationRevision === requestedAtRevision) applySnapshot(next);
+      })
       .catch(() => undefined);
     return () => {
       cancelled = true;
@@ -201,7 +208,7 @@ function UpdateReadyBanner({ blockedReason }: { blockedReason?: string }) {
               Restarting…
             </>
           ) : (
-            "Restart now"
+            "Update and restart"
           )}
         </Button>
       </div>

--- a/renderer/lib/use-voice-recorder.ts
+++ b/renderer/lib/use-voice-recorder.ts
@@ -5,18 +5,29 @@ import * as React from "react";
 import { toast } from "../components/ui";
 import {
   ensureMicrophoneAccess,
+  microphoneCaptureErrorMessage,
+  MICROPHONE_PERMISSION_OFF_MESSAGE,
   transcribeBlob,
   type TranscribeOptions,
 } from "./voice-recorder-core";
+import { DictationOperationGate } from "./dictation-operation-gate";
 
 type RecorderOptions = TranscribeOptions;
 
-export function useVoiceRecorder(onTranscript: (text: string) => void, options: RecorderOptions) {
+export function useVoiceRecorder(
+  onTranscript: (text: string) => void,
+  options: RecorderOptions,
+) {
   const [recording, setRecording] = React.useState(false);
   const [transcribing, setTranscribing] = React.useState(false);
   const recorderRef = React.useRef<MediaRecorder | null>(null);
   const chunksRef = React.useRef<Blob[]>([]);
   const streamRef = React.useRef<MediaStream | null>(null);
+  const operationGateRef = React.useRef<DictationOperationGate | null>(null);
+  if (operationGateRef.current === null) {
+    operationGateRef.current = new DictationOperationGate();
+  }
+  const operationGate = operationGateRef.current;
   // Keep the latest options available to the recorder's stop callback.
   const optionsRef = React.useRef(options);
   optionsRef.current = options;
@@ -27,49 +38,81 @@ export function useVoiceRecorder(onTranscript: (text: string) => void, options: 
   }, []);
 
   const start = React.useCallback(async () => {
+    if (recorderRef.current) return;
+    const token = operationGate.beginStart();
+    if (token === null) return;
     try {
       // Native permission gate before capture.
-      const status = await window.aidenAPI.systemPreferences.getMediaAccessStatus("microphone");
-      if (!(await ensureMicrophoneAccess())) {
+      const status =
+        await window.aidenAPI.systemPreferences.getMediaAccessStatus(
+          "microphone",
+        );
+      const allowed = await ensureMicrophoneAccess();
+      if (!operationGate.isCurrent(token)) return;
+      if (!allowed) {
+        operationGate.finishStart(token);
         toast.error(
           status === "not-determined"
-            ? "Microphone permission was not granted."
-            : "Microphone access is off. Enable it in System Settings → Privacy & Security → Microphone.",
+            ? "Microphone permission was not granted. Enable it in System Settings, then restart Aiden."
+            : MICROPHONE_PERMISSION_OFF_MESSAGE,
         );
         return;
       }
 
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      if (!operationGate.isCurrent(token)) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
       streamRef.current = stream;
       chunksRef.current = [];
-      const mime = MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : "";
-      const recorder = new MediaRecorder(stream, mime ? { mimeType: mime } : undefined);
+      const mime = MediaRecorder.isTypeSupported("audio/webm")
+        ? "audio/webm"
+        : "";
+      const recorder = new MediaRecorder(
+        stream,
+        mime ? { mimeType: mime } : undefined,
+      );
       recorder.ondataavailable = (e) => {
         if (e.data.size > 0) chunksRef.current.push(e.data);
       };
       recorder.onstop = async () => {
         stopTracks();
+        if (!operationGate.isCurrent(token)) return;
         setRecording(false);
-        const blob = new Blob(chunksRef.current, { type: recorder.mimeType || "audio/webm" });
-        if (blob.size === 0) return;
+        const blob = new Blob(chunksRef.current, {
+          type: recorder.mimeType || "audio/webm",
+        });
+        if (blob.size === 0) {
+          if (recorderRef.current === recorder) recorderRef.current = null;
+          return;
+        }
         setTranscribing(true);
         try {
           const text = await transcribeBlob(blob, optionsRef.current);
+          if (!operationGate.isCurrent(token)) return;
           if (text) onTranscript(text);
           else toast.error("No speech detected.");
         } catch (error) {
+          if (!operationGate.isCurrent(token)) return;
           toast.error(error instanceof Error ? error.message : String(error));
         } finally {
-          setTranscribing(false);
+          if (recorderRef.current === recorder) recorderRef.current = null;
+          if (operationGate.isCurrent(token)) setTranscribing(false);
         }
       };
-      recorder.start();
       recorderRef.current = recorder;
+      recorder.start();
+      operationGate.finishStart(token);
       setRecording(true);
-    } catch {
-      toast.error("Microphone access is needed for voice input. Allow it in System Settings → Privacy & Security → Microphone.");
+    } catch (error) {
+      if (!operationGate.isCurrent(token)) return;
+      operationGate.finishStart(token);
+      recorderRef.current = null;
+      stopTracks();
+      toast.error(microphoneCaptureErrorMessage(error));
     }
-  }, [onTranscript, stopTracks]);
+  }, [onTranscript, operationGate, stopTracks]);
 
   const stop = React.useCallback(() => {
     if (recorderRef.current && recorderRef.current.state !== "inactive") {
@@ -77,7 +120,21 @@ export function useVoiceRecorder(onTranscript: (text: string) => void, options: 
     }
   }, []);
 
-  React.useEffect(() => () => stopTracks(), [stopTracks]);
+  React.useEffect(
+    () => () => {
+      operationGate.cancel();
+      const recorder = recorderRef.current;
+      recorderRef.current = null;
+      if (recorder) {
+        recorder.ondataavailable = null;
+        recorder.onstop = null;
+        if (recorder.state !== "inactive") recorder.stop();
+      }
+      chunksRef.current = [];
+      stopTracks();
+    },
+    [operationGate, stopTracks],
+  );
 
   return { recording, transcribing, start, stop };
 }

--- a/renderer/lib/voice-recorder-core.test.ts
+++ b/renderer/lib/voice-recorder-core.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  microphoneCaptureErrorMessage,
+  MICROPHONE_PERMISSION_OFF_MESSAGE,
+} from "./voice-recorder-core.js";
+
+test("microphone capture errors preserve actionable device and permission causes", () => {
+  assert.equal(
+    microphoneCaptureErrorMessage({ name: "NotAllowedError" }),
+    MICROPHONE_PERMISSION_OFF_MESSAGE,
+  );
+  assert.equal(
+    microphoneCaptureErrorMessage({ name: "SecurityError" }),
+    MICROPHONE_PERMISSION_OFF_MESSAGE,
+  );
+  assert.match(
+    microphoneCaptureErrorMessage({ name: "NotFoundError" }),
+    /No microphone was found/u,
+  );
+  assert.match(
+    microphoneCaptureErrorMessage({ name: "NotReadableError" }),
+    /other apps using it/u,
+  );
+  assert.match(
+    microphoneCaptureErrorMessage({ name: "AbortError" }),
+    /interrupted/u,
+  );
+  assert.match(
+    microphoneCaptureErrorMessage(new Error("raw device detail")),
+    /could not start/u,
+  );
+  assert.match(
+    microphoneCaptureErrorMessage(
+      Object.defineProperty({}, "name", {
+        get() {
+          throw new Error("untrusted getter detail");
+        },
+      }),
+    ),
+    /could not start/u,
+  );
+});
+
+test("permission recovery tells users that macOS requires an app restart", () => {
+  assert.match(MICROPHONE_PERMISSION_OFF_MESSAGE, /restart Aiden/u);
+});

--- a/renderer/lib/voice-recorder-core.ts
+++ b/renderer/lib/voice-recorder-core.ts
@@ -13,6 +13,35 @@ export interface TranscribeOptions {
   localModel?: string;
 }
 
+export const MICROPHONE_PERMISSION_OFF_MESSAGE =
+  "Microphone access is off. Enable it in System Settings → Privacy & Security → Microphone, then restart Aiden.";
+
+export function microphoneCaptureErrorMessage(error: unknown): string {
+  let name = "";
+  try {
+    const candidate =
+      typeof error === "object" && error !== null
+        ? (error as { name?: unknown }).name
+        : undefined;
+    if (typeof candidate === "string") name = candidate;
+  } catch {
+    // A hostile or cross-realm error object must not break recovery messaging.
+  }
+  switch (name) {
+    case "NotAllowedError":
+    case "SecurityError":
+      return MICROPHONE_PERMISSION_OFF_MESSAGE;
+    case "NotFoundError":
+      return "No microphone was found. Connect or enable an input device, then try again.";
+    case "NotReadableError":
+      return "Aiden could not read from the microphone. Close other apps using it, check the selected input device, and try again.";
+    case "AbortError":
+      return "Microphone capture was interrupted. Try again.";
+    default:
+      return "Aiden could not start microphone capture. Check the input device and microphone permission, then try again.";
+  }
+}
+
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -26,7 +55,11 @@ function blobToBase64(blob: Blob): Promise<string> {
 }
 
 function float32ToBase64(samples: Float32Array): string {
-  const bytes = new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength);
+  const bytes = new Uint8Array(
+    samples.buffer,
+    samples.byteOffset,
+    samples.byteLength,
+  );
   let binary = "";
   const chunk = 0x8000;
   for (let i = 0; i < bytes.length; i += chunk) {
@@ -59,7 +92,8 @@ async function blobToPcm16k(blob: Blob): Promise<string> {
 
 /** Native mic-permission gate; resolves true when capture may start. */
 export async function ensureMicrophoneAccess(): Promise<boolean> {
-  const status = await window.aidenAPI.systemPreferences.getMediaAccessStatus("microphone");
+  const status =
+    await window.aidenAPI.systemPreferences.getMediaAccessStatus("microphone");
   if (status === "denied" || status === "restricted") return false;
   if (status === "not-determined") {
     return window.aidenAPI.systemPreferences.askForMediaAccess("microphone");
@@ -71,10 +105,15 @@ export async function ensureMicrophoneAccess(): Promise<boolean> {
  * Transcribe a recorded blob through the selected provider.
  * Resolves the trimmed transcript ("" when no speech was detected).
  */
-export async function transcribeBlob(blob: Blob, options: TranscribeOptions): Promise<string> {
+export async function transcribeBlob(
+  blob: Blob,
+  options: TranscribeOptions,
+): Promise<string> {
   if (options.provider === "local") {
     if (!options.localModel) {
-      throw new Error("Download and select an on-device model in Settings → Voice.");
+      throw new Error(
+        "Download and select an on-device model in Settings → Voice.",
+      );
     }
     const pcm = await blobToPcm16k(blob);
     return (await voiceApi.transcribeLocal(pcm, options.localModel)).trim();

--- a/renderer/pill/pill-app.tsx
+++ b/renderer/pill/pill-app.tsx
@@ -8,7 +8,12 @@ import * as React from "react";
 import { Check, ClipboardCopy, Loader2, X } from "lucide-react";
 import { dictationApi, onNotification, settingsApi } from "../lib/ipc";
 import type { DictationStatePayload } from "../shared/dictation";
-import { ensureMicrophoneAccess, transcribeBlob } from "../lib/voice-recorder-core";
+import {
+  ensureMicrophoneAccess,
+  microphoneCaptureErrorMessage,
+  MICROPHONE_PERMISSION_OFF_MESSAGE,
+  transcribeBlob,
+} from "../lib/voice-recorder-core";
 import {
   DictationOperationGate,
   withDictationTimeout,
@@ -95,22 +100,27 @@ export function PillApp() {
     const token = operationGateRef.current.beginStart();
     if (token === null) return;
     setPhase("idle");
+    let pendingStream: MediaStream | null = null;
+    let pendingAudioContext: AudioContext | null = null;
     try {
-      if (!(await ensureMicrophoneAccess())) {
+      const allowed = await ensureMicrophoneAccess();
+      if (!operationGateRef.current.isCurrent(token)) return;
+      if (!allowed) {
         operationGateRef.current.finishStart(token);
-        void dictationApi.reportError(
-          "Microphone access is off. Enable it in System Settings → Privacy & Security → Microphone.",
-        );
+        void dictationApi.reportError(MICROPHONE_PERMISSION_OFF_MESSAGE);
         return;
       }
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      pendingStream = stream;
       if (!operationGateRef.current.isCurrent(token)) {
         stream.getTracks().forEach((track) => track.stop());
+        pendingStream = null;
         return;
       }
       const mime = MediaRecorder.isTypeSupported("audio/webm") ? "audio/webm" : "";
       const recorder = new MediaRecorder(stream, mime ? { mimeType: mime } : undefined);
       const audioContext = new AudioContext();
+      pendingAudioContext = audioContext;
       const analyser = audioContext.createAnalyser();
       analyser.fftSize = 256;
       audioContext.createMediaStreamSource(stream).connect(analyser);
@@ -149,20 +159,22 @@ export function PillApp() {
         })();
       };
       recordingRef.current = active;
+      pendingStream = null;
+      pendingAudioContext = null;
       operationGateRef.current.finishStart(token);
       recorder.start();
       setElapsed(0);
       setPhase("recording");
       startWaveform(analyser);
       timerRef.current = setInterval(() => setElapsed((value) => value + 1), 1_000);
-    } catch {
+    } catch (error) {
       if (!operationGateRef.current.isCurrent(token)) return;
       operationGateRef.current.finishStart(token);
       const active = recordingRef.current;
       if (active) releaseRecording(active);
-      void dictationApi.reportError(
-        "Microphone access is needed for dictation. Allow it in System Settings → Privacy & Security → Microphone.",
-      );
+      pendingStream?.getTracks().forEach((track) => track.stop());
+      if (pendingAudioContext) void pendingAudioContext.close().catch(() => {});
+      void dictationApi.reportError(microphoneCaptureErrorMessage(error));
     }
   }, [releaseRecording, startWaveform]);
 
@@ -222,6 +234,20 @@ export function PillApp() {
       unsubscribe();
     };
   }, [discardRecording, startRecording, stopRecording, stopWaveform]);
+
+  React.useEffect(
+    () => () => {
+      operationGateRef.current.cancel();
+      const active = recordingRef.current;
+      if (!active) return;
+      active.cancelled = true;
+      active.recorder.ondataavailable = null;
+      active.recorder.onstop = null;
+      if (active.recorder.state !== "inactive") active.recorder.stop();
+      releaseRecording(active);
+    },
+    [releaseRecording],
+  );
 
   return (
     <div className="flex h-full w-full items-center justify-center" role="status" aria-live="polite">

--- a/renderer/shared/app-update.test.ts
+++ b/renderer/shared/app-update.test.ts
@@ -29,4 +29,7 @@ test("fails closed for malformed or non-ready update snapshots", () => {
     parseAppUpdateSnapshot({ status: "downloading", version: "0.27.25" }),
     IDLE_APP_UPDATE_SNAPSHOT,
   );
+  assert.equal(normalizeAppUpdateVersion("Aiden Agent 0.27.25"), null);
+  assert.equal(normalizeAppUpdateVersion("0.27.025"), null);
+  assert.equal(normalizeAppUpdateVersion("0.27.25\u202e"), null);
 });

--- a/renderer/shared/app-update.ts
+++ b/renderer/shared/app-update.ts
@@ -22,6 +22,9 @@ export const IDLE_APP_UPDATE_SNAPSHOT: AppUpdateSnapshot = {
   version: null,
 };
 
+const SEMANTIC_APP_UPDATE_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
+
 export function normalizeAppUpdateVersion(value: unknown): string | null {
   if (typeof value !== "string") return null;
   if (
@@ -33,7 +36,7 @@ export function normalizeAppUpdateVersion(value: unknown): string | null {
     return null;
   }
   const version = value.trim();
-  if (!version || version.length > 128) return null;
+  if (!version || version.length > 128 || !SEMANTIC_APP_UPDATE_VERSION.test(version)) return null;
   return version;
 }
 

--- a/resources/entitlements.mac.inherit.plist
+++ b/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>

--- a/scripts/prepare-macos-dev-runtime.mjs
+++ b/scripts/prepare-macos-dev-runtime.mjs
@@ -19,7 +19,9 @@ import { fileURLToPath } from "node:url";
 
 const modulePath = fileURLToPath(import.meta.url);
 const repositoryRoot = path.resolve(path.dirname(modulePath), "..");
-const BRANDING_SCHEMA_VERSION = 4;
+const BRANDING_SCHEMA_VERSION = 5;
+const MICROPHONE_USAGE_DESCRIPTION =
+  "Aiden Agent uses the microphone only when you choose voice input or dictation.";
 
 function helperName(productName, suffix) {
   return `${productName} Helper${suffix}`;
@@ -161,6 +163,7 @@ export async function validateMacDevRuntime(
       CFBundleExecutable: layout.executableName,
       CFBundleIdentifier: layout.bundleIdentifier,
       CFBundleName: layout.productName,
+      NSMicrophoneUsageDescription: MICROPHONE_USAGE_DESCRIPTION,
     },
     run,
   );
@@ -247,6 +250,12 @@ export async function brandMacDevRuntime(
   await setPlistString(mainPlist, "CFBundleIconFile", path.basename(bundledIcon), run);
   await setPlistString(mainPlist, "CFBundleIdentifier", layout.bundleIdentifier, run);
   await setPlistString(mainPlist, "CFBundleName", layout.productName, run);
+  await setPlistString(
+    mainPlist,
+    "NSMicrophoneUsageDescription",
+    MICROPHONE_USAGE_DESCRIPTION,
+    run,
+  );
   await setPlistString(mainPlist, "CFBundleShortVersionString", version, run);
   await setPlistString(mainPlist, "CFBundleVersion", version, run);
 

--- a/scripts/prepare-macos-dev-runtime.test.mjs
+++ b/scripts/prepare-macos-dev-runtime.test.mjs
@@ -184,6 +184,14 @@ test("branding mutates and validates the complete cached app layout", async (t) 
     assert.equal(await plistValue(helperPlist, "CFBundleName"), helper.destinationName);
   }
 
+  assert.equal(
+    await plistValue(
+      path.join(appPath, "Contents", "Info.plist"),
+      "NSMicrophoneUsageDescription",
+    ),
+    "Aiden Agent uses the microphone only when you choose voice input or dictation.",
+  );
+
   await assert.rejects(
     validateMacDevRuntime(appPath, {
       inspectArchitectures: async () => ["arm64"],

--- a/scripts/run-macos-distribution.mjs
+++ b/scripts/run-macos-distribution.mjs
@@ -1,6 +1,8 @@
 /* global console, process */
 
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
 import { lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -72,14 +74,40 @@ export function distributionElectronBuilderArguments(staging, { enableAutoUpdate
 export async function verifyMacUpdateMetadata(staging, expectedVersion) {
   const metadataPath = path.join(staging, "latest-mac.yml");
   const metadata = await readFile(metadataPath, "utf8");
-  if (!metadata.includes(`version: ${expectedVersion}`)) {
+  const versions = [...metadata.matchAll(/^version:\s*(.+?)\s*$/gmu)].map((match) => match[1]);
+  if (versions.length !== 1 || versions[0] !== expectedVersion) {
     throw new Error("macOS update metadata does not match the packaged application version.");
   }
   if (!/^files:\s*$/mu.test(metadata) || !/^\s+- url: .+\.zip\s*$/mu.test(metadata)) {
     throw new Error("macOS update metadata does not identify a ZIP update payload.");
   }
-  if (!/^\s+sha512: [A-Za-z0-9+/=]+\s*$/mu.test(metadata)) {
-    throw new Error("macOS update metadata is missing its signed payload digest.");
+  const archives = await discoverMacDistributionArchives(staging);
+  const zipName = path.basename(archives.zip);
+  if (!/^[A-Za-z0-9._-]+$/u.test(zipName)) {
+    throw new Error("macOS update ZIP name is not stable for GitHub release assets.");
+  }
+  const urls = [...metadata.matchAll(/^\s+- url:\s*(.+?)\s*$/gmu)].map((match) => match[1]);
+  if (urls.length !== 1 || urls[0] !== zipName) {
+    throw new Error("macOS update metadata does not name the exact ZIP release asset.");
+  }
+  const paths = [...metadata.matchAll(/^path:\s*(.+?)\s*$/gmu)].map((match) => match[1]);
+  if (paths.length !== 1 || paths[0] !== zipName) {
+    throw new Error("macOS update metadata path does not name the exact ZIP release asset.");
+  }
+  const fileDigests = [...metadata.matchAll(/^\s+sha512:\s*([A-Za-z0-9+/=]+)\s*$/gmu)].map(
+    (match) => match[1],
+  );
+  const legacyDigests = [...metadata.matchAll(/^sha512:\s*([A-Za-z0-9+/=]+)\s*$/gmu)].map(
+    (match) => match[1],
+  );
+  if (fileDigests.length !== 1 || legacyDigests.length !== 1) {
+    throw new Error("macOS update metadata must contain both ZIP payload digests.");
+  }
+  const digest = createHash("sha512");
+  for await (const chunk of createReadStream(archives.zip)) digest.update(chunk);
+  const actualDigest = digest.digest("base64");
+  if (fileDigests[0] !== actualDigest || legacyDigests[0] !== actualDigest) {
+    throw new Error("macOS update metadata digest does not match the exact ZIP release asset.");
   }
   return metadataPath;
 }

--- a/scripts/run-macos-distribution.test.mjs
+++ b/scripts/run-macos-distribution.test.mjs
@@ -1,10 +1,12 @@
 /* global process */
 
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { URL } from "node:url";
 import {
   AIDEN_UPDATE_FEED_URL,
   discoverMacDistributionArchives,
@@ -125,15 +127,68 @@ test("automatic-update distributions generate generic-feed metadata without chan
   ]);
 });
 
+test("release artifact configuration uses stable GitHub-safe names", async () => {
+  const packageJson = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  assert.equal(packageJson.build.mac.artifactName, "Aiden-Agent-${version}-${arch}-mac.${ext}");
+  assert.equal(packageJson.build.dmg.artifactName, "Aiden-Agent-Beta-${version}-${arch}.${ext}");
+});
+
+test("release assets stay draft-only until the complete update set is uploaded", async () => {
+  const workflow = await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+  const existingReleaseGuard = workflow.indexOf('gh release view "$RELEASE_TAG"');
+  const createDraft = workflow.indexOf('gh release create "$RELEASE_TAG"');
+  const publishDraft = workflow.indexOf('gh release edit "$RELEASE_TAG"');
+
+  assert.ok(existingReleaseGuard >= 0, "release reruns must reject an existing tag or draft");
+  assert.ok(createDraft > existingReleaseGuard, "draft creation must follow the immutability guard");
+  assert.ok(publishDraft > createDraft, "publication must happen only after draft asset upload");
+
+  const upload = workflow.slice(createDraft, publishDraft);
+  assert.match(upload, /--draft\s+\\\s+-- \*\.dmg \*\.zip latest-mac\.yml SHA256SUMS/u);
+  assert.doesNotMatch(upload, /--latest/u);
+
+  const publish = workflow.slice(publishDraft);
+  assert.match(publish, /--draft=false\s+\\\s+--latest/u);
+});
+
 test("update metadata is version-bound and requires a hashed ZIP payload", async () => {
   const staging = await mkdtemp(path.join(os.tmpdir(), "aiden-update-metadata-"));
   try {
+    const zipContents = "fixture";
+    const zipDigest = createHash("sha512").update(zipContents).digest("base64");
+    await Promise.all([
+      writeFile(path.join(staging, "Aiden-Agent-Beta-1.0.9-arm64.dmg"), "fixture", "utf8"),
+      writeFile(path.join(staging, "Aiden-Agent-1.0.9-arm64-mac.zip"), zipContents, "utf8"),
+    ]);
     await writeFile(
       path.join(staging, "latest-mac.yml"),
-      "version: 1.0.9\nfiles:\n  - url: Aiden-Agent-1.0.9.zip\n    sha512: YWlkZW4=\n",
+      `version: 1.0.9\nfiles:\n  - url: Aiden-Agent-1.0.9-arm64-mac.zip\n    sha512: ${zipDigest}\npath: Aiden-Agent-1.0.9-arm64-mac.zip\nsha512: ${zipDigest}\n`,
       "utf8",
     );
-    assert.equal(await verifyMacUpdateMetadata(staging, "1.0.9"), path.join(staging, "latest-mac.yml"));
+    assert.equal(
+      await verifyMacUpdateMetadata(staging, "1.0.9"),
+      path.join(staging, "latest-mac.yml"),
+    );
+    await assert.rejects(verifyMacUpdateMetadata(staging, "1.0.10"), /does not match/u);
+    await writeFile(
+      path.join(staging, "latest-mac.yml"),
+      `version: 1.0.9\nfiles:\n  - url: Aiden Agent-1.0.9-arm64-mac.zip\n    sha512: ${zipDigest}\npath: Aiden Agent-1.0.9-arm64-mac.zip\nsha512: ${zipDigest}\n`,
+      "utf8",
+    );
+    await assert.rejects(verifyMacUpdateMetadata(staging, "1.0.9"), /exact ZIP release asset/u);
+    await writeFile(
+      path.join(staging, "latest-mac.yml"),
+      `version: 1.0.9\nfiles:\n  - url: Aiden-Agent-1.0.9-arm64-mac.zip\n    sha512: ${zipDigest}\npath: Aiden-Agent-1.0.9-arm64-mac.zip\nsha512: YWlkZW4=\n`,
+      "utf8",
+    );
+    await assert.rejects(verifyMacUpdateMetadata(staging, "1.0.9"), /digest does not match/u);
+    await writeFile(
+      path.join(staging, "latest-mac.yml"),
+      `version: 1.0.9\nreleaseName: version: 1.0.10\nfiles:\n  - url: Aiden-Agent-1.0.9-arm64-mac.zip\n    sha512: ${zipDigest}\npath: Aiden-Agent-1.0.9-arm64-mac.zip\nsha512: ${zipDigest}\n`,
+      "utf8",
+    );
     await assert.rejects(verifyMacUpdateMetadata(staging, "1.0.10"), /does not match/u);
   } finally {
     await rm(staging, { recursive: true, force: true });

--- a/scripts/verify-macos-package.mjs
+++ b/scripts/verify-macos-package.mjs
@@ -69,6 +69,7 @@ const SUBAGENT_RUN_STORE_EXECUTABLE = "aiden-subagent-run-store";
 const SUBAGENT_FILE_MUTATOR_EXECUTABLE = "aiden-subagent-file-mutator";
 const SUBAGENT_SHELL_RUNNER_EXECUTABLE = "aiden-subagent-shell-runner";
 const REQUIRED_UNIVERSAL_ARCHITECTURES = Object.freeze(["arm64", "x86_64"]);
+const ELECTRON_HELPER_SUFFIXES = Object.freeze(["", " (GPU)", " (Plugin)", " (Renderer)"]);
 
 async function run(command, args) {
   return executeFile(command, args, {
@@ -321,19 +322,47 @@ export function assertMinimalComputerUseEntitlements(entitlements) {
   }
 }
 
-export function assertElectronEntitlements(entitlements) {
-  const expected = [
-    "com.apple.security.automation.apple-events",
-    "com.apple.security.cs.allow-jit",
-    "com.apple.security.cs.allow-unsigned-executable-memory",
-    "com.apple.security.cs.disable-library-validation",
-  ].sort();
-  const actual = [...entitlements.matchAll(/<key>([^<]+)<\/key>/g)].map((match) => match[1]).sort();
-  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-    throw new Error(
-      `Electron executable entitlements differ from the pinned runtime set: ${actual.join(", ")}`,
-    );
+function assertExactTrueEntitlements(entitlements, expectedKeys, description) {
+  const expected = [...expectedKeys].sort();
+  const actual = [...entitlements.matchAll(/<key>([^<]+)<\/key>/g)]
+    .map((match) => match[1])
+    .sort();
+  const enabled = [...entitlements.matchAll(/<key>([^<]+)<\/key>\s*<true\s*\/>/g)]
+    .map((match) => match[1])
+    .sort();
+  if (
+    JSON.stringify(actual) !== JSON.stringify(expected) ||
+    JSON.stringify(enabled) !== JSON.stringify(expected)
+  ) {
+    throw new Error(`${description}: ${actual.join(", ")}`);
   }
+}
+
+export function assertElectronEntitlements(entitlements) {
+  assertExactTrueEntitlements(
+    entitlements,
+    [
+      "com.apple.security.automation.apple-events",
+      "com.apple.security.cs.allow-jit",
+      "com.apple.security.cs.allow-unsigned-executable-memory",
+      "com.apple.security.cs.disable-library-validation",
+      "com.apple.security.device.audio-input",
+    ],
+    "Electron executable entitlements differ from the pinned runtime set",
+  );
+}
+
+export function assertElectronHelperEntitlements(entitlements) {
+  assertExactTrueEntitlements(
+    entitlements,
+    [
+      "com.apple.security.cs.allow-jit",
+      "com.apple.security.cs.allow-unsigned-executable-memory",
+      "com.apple.security.cs.disable-library-validation",
+      "com.apple.security.device.audio-input",
+    ],
+    "Electron helper entitlements differ from the pinned inherited set",
+  );
 }
 
 async function readInfoPlistValue(infoPlist, key) {
@@ -419,6 +448,17 @@ export async function verifyMacPackage(appPath) {
     "Helpers",
     SUBAGENT_SHELL_RUNNER_EXECUTABLE,
   );
+  const electronHelpers = ELECTRON_HELPER_SUFFIXES.map((suffix) =>
+    path.join(
+      paths.app,
+      "Contents",
+      "Frameworks",
+      `Aiden Agent Helper${suffix}.app`,
+      "Contents",
+      "MacOS",
+      `Aiden Agent Helper${suffix}`,
+    ),
+  );
   for (const file of [
     paths.broker,
     paths.driver,
@@ -428,6 +468,7 @@ export async function verifyMacPackage(appPath) {
     paths.outerProvenance,
     paths.outerLicenseNotice,
     paths.electronExecutable,
+    ...electronHelpers,
     worktreeRemover,
     subagentRunStore,
     subagentFileMutator,
@@ -505,6 +546,7 @@ export async function verifyMacPackage(appPath) {
         paths.broker,
         paths.driver,
         paths.electronExecutable,
+        ...electronHelpers,
         worktreeRemover,
         subagentRunStore,
         subagentFileMutator,
@@ -544,6 +586,9 @@ export async function verifyMacPackage(appPath) {
   assertMinimalComputerUseEntitlements(await readEntitlements(subagentRunStore));
   assertMinimalComputerUseEntitlements(await readEntitlements(subagentFileMutator));
   assertElectronEntitlements(await readEntitlements(paths.electronExecutable));
+  for (const electronHelper of electronHelpers) {
+    assertElectronHelperEntitlements(await readEntitlements(electronHelper));
+  }
   await verifyAidenFuses(paths.app);
   console.log(`Verified hardened macOS package: ${paths.app}`);
 }

--- a/scripts/verify-macos-package.test.mjs
+++ b/scripts/verify-macos-package.test.mjs
@@ -14,6 +14,7 @@ import {
   assertComputerUseMinimumSystemVersion,
   assertDeveloperIdSignature,
   assertElectronEntitlements,
+  assertElectronHelperEntitlements,
   assertExactUniversalArchitectures,
   assertMinimalComputerUseEntitlements,
   assertMacOSArchitectureMinimum,
@@ -400,6 +401,7 @@ test("package verifier requires the normal Electron runtime entitlements", () =>
     "com.apple.security.cs.allow-jit",
     "com.apple.security.cs.allow-unsigned-executable-memory",
     "com.apple.security.cs.disable-library-validation",
+    "com.apple.security.device.audio-input",
   ]
     .map((key) => `<key>${key}</key><true/>`)
     .join("");
@@ -408,8 +410,53 @@ test("package verifier requires the normal Electron runtime entitlements", () =>
   assert.throws(
     () =>
       assertElectronEntitlements(
+        `<plist><dict>${expected.replace(
+          "<key>com.apple.security.device.audio-input</key><true/>",
+          "<key>com.apple.security.device.audio-input</key><false/>",
+        )}</dict></plist>`,
+      ),
+    /pinned runtime set/u,
+  );
+  assert.throws(
+    () =>
+      assertElectronEntitlements(
         `<plist><dict>${expected}<key>com.apple.security.app-sandbox</key><true/></dict></plist>`,
       ),
     /pinned runtime set/,
+  );
+});
+
+test("package verifier requires inherited microphone access on Electron helpers", () => {
+  const expected = [
+    "com.apple.security.cs.allow-jit",
+    "com.apple.security.cs.allow-unsigned-executable-memory",
+    "com.apple.security.cs.disable-library-validation",
+    "com.apple.security.device.audio-input",
+  ]
+    .map((key) => `<key>${key}</key><true/>`)
+    .join("");
+  assert.doesNotThrow(() =>
+    assertElectronHelperEntitlements(`<plist><dict>${expected}</dict></plist>`),
+  );
+  assert.throws(
+    () => assertElectronHelperEntitlements("<plist><dict/></plist>"),
+    /pinned inherited set/u,
+  );
+  assert.throws(
+    () =>
+      assertElectronHelperEntitlements(
+        `<plist><dict>${expected.replace(
+          "<key>com.apple.security.device.audio-input</key><true/>",
+          "<key>com.apple.security.device.audio-input</key><false/>",
+        )}</dict></plist>`,
+      ),
+    /pinned inherited set/u,
+  );
+  assert.throws(
+    () =>
+      assertElectronHelperEntitlements(
+        `<plist><dict>${expected}<key>com.apple.security.automation.apple-events</key><true/></dict></plist>`,
+      ),
+    /pinned inherited set/u,
   );
 });


### PR DESCRIPTION
## What changed

- make macOS update archive names GitHub-safe and bind `latest-mac.yml` to one exact version, ZIP basename, and recomputed SHA-512
- upload the complete release asset set to a draft before atomically publishing it as latest
- preserve newer updater notifications when the initial state request resolves late, validate displayed SemVer, and expose the guarded **Update and restart** action
- add the hardened-runtime microphone entitlement to the app and inherited Electron helpers
- verify all four Electron helpers have the exact required entitlements enabled
- cancel stale microphone starts and release streams/audio contexts across setup failures, cancellation, and unmount
- publish provider-compatible fixed-length coordinate schemas and reject sparse/holey coordinates at runtime

## Root causes

The 0.27 updater manifest named a ZIP with spaces while GitHub published a normalized filename, leaving the manifest reachable but the payload unavailable. Signed builds also omitted `com.apple.security.device.audio-input`, and Computer Use used tuple JSON Schema whose array-valued `items` was rejected by Moonshot-compatible providers.

Three independent adversarial reviews additionally found checksum/version ambiguity, partial release visibility, updater IPC races, microphone resource leaks and incomplete helper verification, and a sparse-array coordinate bypass.

The separate provider error `Stream ended without finish_reason` remains fail-closed. Treating a potentially truncated stream as success could execute incomplete tool arguments.

## Validation

- `npm run type-check`
- `npm run lint`
- `npm run test:branding`
- focused updater, release, signing, microphone lifecycle, and Computer Use adversarial suites
- `npm test`
- `plutil -lint resources/entitlements.mac.plist resources/entitlements.mac.inherit.plist`
- React Doctor reviewed the changed UI; its actionable lazy-ref finding was fixed. The remaining changed-file warning is the intentional update-banner exit-animation state.

## Remaining release acceptance

- publish a new immutable release and verify an installed 0.27.0 app downloads it, shows **Update and restart**, and relaunches successfully
- run clean-TCC signed-package microphone acceptance for composer voice input and the global dictation pill
