### PR TITLE
Fix packaged subprocess lockdown verification

### DIFF
--- a/scripts/verify-macos-package.mjs
+++ b/scripts/verify-macos-package.mjs
@@ -183,7 +183,9 @@ export async function verifyPackagedSubagentInferenceWorker(appAsar) {
   const promiseLockdownIndex = bootstrap.indexOf(
     'Object.defineProperty(childProcess, "promises"',
   );
-  const syncIndex = bootstrap.indexOf("syncBuiltinESMExports");
+  // The emitted ESM bootstrap names this symbol in its import before any
+  // lockdown code. Match the invocation, not the import declaration.
+  const syncIndex = bootstrap.indexOf("syncBuiltinESMExports();", promiseLockdownIndex);
   const runtimeImportIndex = bootstrap.indexOf("subagent-inference-worker-runtime.js");
   const requiredSubprocessNames = [
     '"exec"',

--- a/scripts/verify-macos-package.test.mjs
+++ b/scripts/verify-macos-package.test.mjs
@@ -170,7 +170,7 @@ test("package verifier requires a bounded packed subagent inference worker", asy
     await mkdir(workerDirectory, { recursive: true });
     await writeFile(
       path.join(workerDirectory, "subagent-inference-worker.js"),
-      'throw new Error("Provider credential subprocesses are disabled");\nconst names = ["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"];\nObject.defineProperty(childProcess, name, { configurable: false, writable: false });\nObject.defineProperty(childProcess, "promises", { value: Object.freeze({ exec, execFile, fork, spawn }), configurable: false, writable: false });\nsyncBuiltinESMExports();\nawait import("./subagent-inference-worker-runtime.js");\n',
+      'import { syncBuiltinESMExports } from "node:module";\nthrow new Error("Provider credential subprocesses are disabled");\nconst names = ["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"];\nObject.defineProperty(childProcess, name, { configurable: false, writable: false });\nObject.defineProperty(childProcess, "promises", { value: Object.freeze({ exec, execFile, fork, spawn }), configurable: false, writable: false });\nsyncBuiltinESMExports();\nawait import("./subagent-inference-worker-runtime.js");\n',
     );
     await writeFile(
       path.join(workerDirectory, "subagent-inference-worker-runtime.js"),

--- a/tests/e2e/assistant-scheduled-profile.spec.ts
+++ b/tests/e2e/assistant-scheduled-profile.spec.ts
@@ -33,8 +33,11 @@ test("local Assistant, Scheduled, Profile, and About surfaces stay safe to explo
   await expect(page.getByText("Scheduled tasks", { exact: true }).first()).toBeVisible();
   const taskSearch = page.getByRole("searchbox", { name: "Search scheduled tasks" });
   await taskSearch.fill("definitely-not-a-schedule");
+  await expect(taskSearch).toHaveValue("definitely-not-a-schedule");
   await expect(page.getByText("No matching tasks", { exact: true })).toBeVisible();
   await taskSearch.fill("");
+  await expect(taskSearch).toHaveValue("");
+  await expect(page.getByText("No matching tasks", { exact: true })).toHaveCount(0);
   await page.getByRole("tab", { name: "Active", exact: true }).click();
   await expect(page.getByRole("tab", { name: "Active", exact: true })).toHaveAttribute(
     "aria-selected",


### PR DESCRIPTION
## Summary
- match the emitted syncBuiltinESMExports invocation instead of its earlier ESM import
- exercise the real import-before-lockdown bootstrap shape in the package verifier test

## Validation
- node --test scripts/verify-macos-package.test.mjs
- npm run type-check
- ESLint on changed files
- git diff --check

Follow-up to the post-merge macOS release failure in run 31940716687.