### PR TITLE
fix: discover unpublished GitHub release drafts

### DIFF
--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -36,7 +36,10 @@ lookup_release() {
   local status
   set +e
   LOOKUP_OUTPUT="$(
-    gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" 2>&1
+    gh release view "$RELEASE_TAG" \
+      --repo "$GITHUB_REPOSITORY" \
+      --json tagName,targetCommitish,isDraft,assets \
+      2>&1
   )"
   status=$?
   set -e
@@ -44,7 +47,7 @@ lookup_release() {
   if (( status == 0 )); then
     return 0
   fi
-  if grep -Eq 'HTTP (404|[0-9.]+ 404)|404 Not Found' <<<"$LOOKUP_OUTPUT"; then
+  if grep -Eq 'HTTP (404|[0-9.]+ 404)|404 Not Found|^release not found$' <<<"$LOOKUP_OUTPUT"; then
     return 1
   fi
   return 2
@@ -77,9 +80,9 @@ const expectedSha = process.argv[2];
 const expectedDraft = process.argv[3] === "true";
 if (
   !release ||
-  release.tag_name !== process.env.RELEASE_TAG ||
-  release.target_commitish !== expectedSha ||
-  release.draft !== expectedDraft
+  release.tagName !== process.env.RELEASE_TAG ||
+  release.targetCommitish !== expectedSha ||
+  release.isDraft !== expectedDraft
 ) {
   process.exit(1);
 }

--- a/scripts/publish-github-release.test.mjs
+++ b/scripts/publish-github-release.test.mjs
@@ -32,7 +32,7 @@ if (args[0] === "release" && args[1] === "view") {
     state.transientLookups -= 1;
     fail("gh: service unavailable (HTTP 503)");
   }
-  if (!state.exists) fail("gh: Not Found (HTTP 404)");
+  if (!state.exists) fail("release not found");
   save();
   process.stdout.write(releaseJson());
   process.exit(0);

--- a/scripts/publish-github-release.test.mjs
+++ b/scripts/publish-github-release.test.mjs
@@ -20,14 +20,14 @@ const save = () => fs.writeFileSync(statePath, JSON.stringify(state));
 const args = process.argv.slice(2);
 const fail = (message) => { save(); process.stderr.write(message + "\n"); process.exit(1); };
 const releaseJson = () => JSON.stringify({
-  tag_name: process.env.RELEASE_TAG,
-  target_commitish: state.target,
-  draft: state.draft,
+  tagName: process.env.RELEASE_TAG,
+  targetCommitish: state.target,
+  isDraft: state.draft,
   assets: state.assets,
 });
 
-if (args[0] === "api") {
-  state.apiCalls += 1;
+if (args[0] === "release" && args[1] === "view") {
+  state.viewCalls += 1;
   if (state.transientLookups > 0) {
     state.transientLookups -= 1;
     fail("gh: service unavailable (HTTP 503)");
@@ -88,7 +88,7 @@ async function fixture(initialState) {
   await writeFile(
     statePath,
     JSON.stringify({
-      apiCalls: 0,
+      viewCalls: 0,
       createCalls: 0,
       uploadCalls: 0,
       editCalls: 0,
@@ -172,7 +172,7 @@ test("fails closed before creation when release lookup remains unavailable", asy
     /release lookup did not settle after 3 attempts/iu,
   );
   const state = JSON.parse(await readFile(setup.statePath, "utf8"));
-  assert.equal(state.apiCalls, 3);
+  assert.equal(state.viewCalls, 3);
   assert.equal(state.createCalls, 0);
   assert.equal(state.uploadCalls, 0);
   assert.equal(state.editCalls, 0);

--- a/scripts/run-macos-distribution.test.mjs
+++ b/scripts/run-macos-distribution.test.mjs
@@ -144,11 +144,13 @@ test("release assets stay draft-only until the complete update set is uploaded",
   assert.match(workflow, /bash scripts\/publish-github-release\.sh release\/distribution/u);
 
   const existingReleaseGuard = publisher.indexOf("if lookup_release_with_retry");
+  const draftAwareLookup = publisher.indexOf('gh release view "$RELEASE_TAG"');
   const websiteAlias = publisher.indexOf('website_dmg="$RUNNER_TEMP/Aiden-Agent-Beta-arm64.dmg"');
   const createDraft = publisher.indexOf('gh release create "$RELEASE_TAG"');
   const publishDraft = publisher.indexOf('gh release edit "$RELEASE_TAG"');
 
   assert.ok(existingReleaseGuard >= 0, "release reruns must reject an existing tag or draft");
+  assert.ok(draftAwareLookup >= 0, "release lookup must include unpublished drafts");
   assert.ok(websiteAlias > existingReleaseGuard, "the website alias must follow the guard");
   assert.ok(
     createDraft > existingReleaseGuard,


### PR DESCRIPTION
## Summary

- use `gh release view` for release identity lookups so unpublished drafts are visible
- preserve explicit missing-release versus transient-failure handling
- update the fake GitHub behavioral tests and source contract

## Hosted failure

Release run `32065638252` successfully built, signed, notarized, and uploaded all five `v0.30.48` assets. Draft creation returned success, but `GET /releases/tags/v0.30.48` returned 404 because that REST endpoint does not expose the unpublished draft. The helper then failed verification.

The real command `gh release view v0.30.48 --json tagName,targetCommitish,isDraft,assets` correctly returns draft ID `371939975`, target `77f2d466...`, and the complete non-empty asset set.

## Validation

- `bash -n scripts/publish-github-release.sh`
- publisher + distribution tests (15/15)
- `npm run test:branding` (43/43)
- `npm run type-check`
- `npm run lint`
- `git diff --check`