### PR TITLE
chore: enforce the legacy download redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,12 @@ The checked-in models.dev snapshot is refreshed only through `npm run models:ref
 
 Aiden Agent is a beta macOS release. Signed DMG and ZIP builds, checksums, and automatic-update metadata are published through [GitHub Releases](https://github.com/sambitcreate/aiden-agent/releases). The release workflow is fail-closed: it verifies signing, notarization, package contents, updater metadata, and version monotonicity before publishing. See [the release guide](docs/releasing.md) for the complete process.
 
+The canonical website download is the stable
+[`Aiden-Agent-Beta-arm64.dmg`](https://github.com/sambitcreate/aiden-agent/releases/latest/download/Aiden-Agent-Beta-arm64.dmg)
+alias from the latest public release. The historical
+`download.chatwithaiden.com/Aiden-Agent-Beta.dmg` URL is maintained by the
+[`aiden-website`](https://github.com/sambitcreate/aiden-website) repository as a non-cacheable
+redirect to that same alias; its R2 object is rollback fallback only. Release preflight checks both
+paths so a stale legacy download fails closed before signing begins.
+
 The project is MIT licensed (see [LICENSE](LICENSE)).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,9 +32,12 @@ visitors and installed apps can download GitHub Release assets without a GitHub 
   Homebrew downloads; the ZIP and YAML are the updater payload.
 - Release-related pull requests run the separate release-consumer contract workflow. It verifies
   the versioned DMG name against `sambitcreate/homebrew-tap`, verifies the deployed website points
-  at the stable alias, and confirms that alias resolves to a non-empty public DMG. The release job
-  repeats this check before spending signing/notarization resources. If the artifact contract must
-  change, update and deploy the consumers first, then change Aiden's release configuration.
+  at the stable alias, confirms that alias resolves to a non-empty public DMG, and requires the
+  historical `download.chatwithaiden.com/Aiden-Agent-Beta.dmg` URL to return a non-cacheable HTTP
+  307 redirect to the same alias. The redirect Worker is owned by `sambitcreate/aiden-website`; its
+  underlying R2 object is rollback fallback only. The release job repeats this check before spending
+  signing/notarization resources. If the artifact contract must change, update and deploy the
+  consumers first, then change Aiden's release configuration.
 - Aiden checks shortly after launch and every six hours. It owns and observes one full-package
   download of a newer signed update rather than using differential updates because the release
   set does not publish separate blockmaps. Settings → About and the chat sidebar expose bounded progress, failure,

--- a/scripts/check-release-consumers.mjs
+++ b/scripts/check-release-consumers.mjs
@@ -64,7 +64,10 @@ export function verifyLegacyWebsiteDmgContract(response) {
       `The legacy website DMG URL must redirect with HTTP 307 to ${WEBSITE_DMG_URL}.`,
     );
   }
-  if (response.headers.get("cache-control") !== "no-store") {
+  const cacheDirectives = (response.headers.get("cache-control") ?? "")
+    .split(",")
+    .map((directive) => directive.trim().toLowerCase());
+  if (!cacheDirectives.includes("no-store")) {
     throw new Error("The legacy website DMG redirect must not be cached.");
   }
 }

--- a/scripts/check-release-consumers.mjs
+++ b/scripts/check-release-consumers.mjs
@@ -8,8 +8,8 @@ const modulePath = fileURLToPath(import.meta.url);
 const repositoryRoot = path.resolve(path.dirname(modulePath), "..");
 
 export const WEBSITE_DMG_NAME = "Aiden-Agent-Beta-arm64.dmg";
-export const WEBSITE_DMG_URL =
-  `https://github.com/sambitcreate/aiden-agent/releases/latest/download/${WEBSITE_DMG_NAME}`;
+export const WEBSITE_DMG_URL = `https://github.com/sambitcreate/aiden-agent/releases/latest/download/${WEBSITE_DMG_NAME}`;
+export const LEGACY_WEBSITE_DMG_URL = "https://download.chatwithaiden.com/Aiden-Agent-Beta.dmg";
 
 export const RELEASE_CONSUMER_URLS = Object.freeze({
   homebrewCask:
@@ -18,6 +18,7 @@ export const RELEASE_CONSUMER_URLS = Object.freeze({
     "https://raw.githubusercontent.com/sambitcreate/homebrew-tap/main/scripts/update-aiden-cask.sh",
   website: "https://chatwithaiden.com/",
   websiteDmg: WEBSITE_DMG_URL,
+  legacyWebsiteDmg: LEGACY_WEBSITE_DMG_URL,
 });
 
 const EXPECTED_VERSIONED_DMG = "Aiden-Agent-Beta-${version}-${arch}.${ext}";
@@ -57,17 +58,34 @@ export function verifyWebsiteReleaseContract(html) {
   );
 }
 
-async function request(fetchImpl, url, { method = "GET" } = {}) {
+export function verifyLegacyWebsiteDmgContract(response) {
+  if (response.status !== 307 || response.headers.get("location") !== WEBSITE_DMG_URL) {
+    throw new Error(
+      `The legacy website DMG URL must redirect with HTTP 307 to ${WEBSITE_DMG_URL}.`,
+    );
+  }
+  if (response.headers.get("cache-control") !== "no-store") {
+    throw new Error("The legacy website DMG redirect must not be cached.");
+  }
+}
+
+async function request(
+  fetchImpl,
+  url,
+  { method = "GET", redirect = "follow", expectedStatus } = {},
+) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15_000);
   try {
     const response = await fetchImpl(url, {
       method,
-      redirect: "follow",
+      redirect,
       signal: controller.signal,
       headers: { "user-agent": "aiden-release-consumer-check" },
     });
-    if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}.`);
+    if (expectedStatus === undefined ? !response.ok : response.status !== expectedStatus) {
+      throw new Error(`${url} returned HTTP ${response.status}.`);
+    }
     return response;
   } finally {
     clearTimeout(timeout);
@@ -82,20 +100,24 @@ async function responseText(fetchImpl, url) {
 }
 
 export async function checkReleaseConsumers({ fetchImpl = fetch, log = console.log } = {}) {
-  const packageJson = JSON.parse(
-    await readFile(path.join(repositoryRoot, "package.json"), "utf8"),
-  );
+  const packageJson = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
   verifyLocalReleaseContract(packageJson);
 
-  const [cask, updater, website, websiteDmg] = await Promise.all([
+  const [cask, updater, website, websiteDmg, legacyWebsiteDmg] = await Promise.all([
     responseText(fetchImpl, RELEASE_CONSUMER_URLS.homebrewCask),
     responseText(fetchImpl, RELEASE_CONSUMER_URLS.homebrewUpdater),
     responseText(fetchImpl, RELEASE_CONSUMER_URLS.website),
     request(fetchImpl, RELEASE_CONSUMER_URLS.websiteDmg, { method: "HEAD" }),
+    request(fetchImpl, RELEASE_CONSUMER_URLS.legacyWebsiteDmg, {
+      method: "HEAD",
+      redirect: "manual",
+      expectedStatus: 307,
+    }),
   ]);
 
   verifyHomebrewReleaseContract({ cask, updater });
   verifyWebsiteReleaseContract(website);
+  verifyLegacyWebsiteDmgContract(legacyWebsiteDmg);
 
   const downloadSize = Number(websiteDmg.headers.get("content-length") ?? 0);
   if (!Number.isSafeInteger(downloadSize) || downloadSize <= 0) {
@@ -103,7 +125,9 @@ export async function checkReleaseConsumers({ fetchImpl = fetch, log = console.l
   }
   const contentType = websiteDmg.headers.get("content-type") ?? "";
   if (!/(?:x-apple-diskimage|octet-stream)/iu.test(contentType)) {
-    throw new Error(`The stable website DMG URL returned an unexpected content type: ${contentType}`);
+    throw new Error(
+      `The stable website DMG URL returned an unexpected content type: ${contentType}`,
+    );
   }
 
   log(`Release consumers are aligned; the website DMG is ${downloadSize} bytes.`);

--- a/scripts/check-release-consumers.test.mjs
+++ b/scripts/check-release-consumers.test.mjs
@@ -6,6 +6,7 @@ import {
   checkReleaseConsumers,
   RELEASE_CONSUMER_URLS,
   verifyHomebrewReleaseContract,
+  verifyLegacyWebsiteDmgContract,
   verifyLocalReleaseContract,
   verifyWebsiteReleaseContract,
   WEBSITE_DMG_URL,
@@ -22,6 +23,14 @@ test("release consumer contract accepts the coordinated stable and versioned DMG
   assert.doesNotThrow(() => verifyLocalReleaseContract(packageJson));
   assert.doesNotThrow(() => verifyHomebrewReleaseContract({ cask, updater }));
   assert.doesNotThrow(() => verifyWebsiteReleaseContract(website));
+  assert.doesNotThrow(() =>
+    verifyLegacyWebsiteDmgContract(
+      new Response(null, {
+        status: 307,
+        headers: { "cache-control": "no-store", location: WEBSITE_DMG_URL },
+      }),
+    ),
+  );
 });
 
 test("release consumer contract fails closed when any consumer drifts", () => {
@@ -38,6 +47,20 @@ test("release consumer contract fails closed when any consumer drifts", () => {
     /Homebrew updater/u,
   );
   assert.throws(() => verifyWebsiteReleaseContract("old website"), /production website/u);
+  assert.throws(
+    () =>
+      verifyLegacyWebsiteDmgContract(
+        new Response(null, { status: 307, headers: { location: "https://old.example/dmg" } }),
+      ),
+    /legacy website DMG URL/u,
+  );
+  assert.throws(
+    () =>
+      verifyLegacyWebsiteDmgContract(
+        new Response(null, { status: 307, headers: { location: WEBSITE_DMG_URL } }),
+      ),
+    /must not be cached/u,
+  );
 });
 
 test("live consumer check validates remote text and the stable DMG response", async () => {
@@ -52,6 +75,13 @@ test("live consumer check validates remote text and the stable DMG response", as
           "content-length": "42",
           "content-type": "application/x-apple-diskimage",
         },
+      }),
+    ],
+    [
+      RELEASE_CONSUMER_URLS.legacyWebsiteDmg,
+      new Response(null, {
+        status: 307,
+        headers: { "cache-control": "no-store", location: WEBSITE_DMG_URL },
       }),
     ],
   ]);

--- a/scripts/check-release-consumers.test.mjs
+++ b/scripts/check-release-consumers.test.mjs
@@ -27,7 +27,7 @@ test("release consumer contract accepts the coordinated stable and versioned DMG
     verifyLegacyWebsiteDmgContract(
       new Response(null, {
         status: 307,
-        headers: { "cache-control": "no-store", location: WEBSITE_DMG_URL },
+        headers: { "cache-control": "NO-STORE, max-age=0", location: WEBSITE_DMG_URL },
       }),
     ),
   );


### PR DESCRIPTION
## Summary
- verify the historical download URL returns a non-cacheable 307 to the canonical GitHub release alias
- document the canonical and fallback download contract in the README and release guide
- preserve the existing website, Homebrew, and stable-DMG preflight checks

## Verification
- node --test scripts/check-release-consumers.test.mjs
- npm run type-check
- npm run lint
- npm run release:check-consumers
- npx oxfmt --check scripts/check-release-consumers.mjs scripts/check-release-consumers.test.mjs README.md docs/releasing.md