### PR TITLE
test(subagents): stabilize detached fixture PID polling

### DIFF
--- a/main/services/subagents/subagent-shell-runner-io.test.ts
+++ b/main/services/subagents/subagent-shell-runner-io.test.ts
@@ -223,13 +223,18 @@ test("a deliberate setsid double-fork proves the documented containment limit an
   const result = await run(t, `${fixture} ${marker}`);
   assert.equal(result.outcome, "exited");
   let pid = 0;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  const markerDeadline = Date.now() + 5_000;
+  while (Date.now() < markerDeadline) {
     try {
-      pid = Number.parseInt(await readFile(marker, "utf8"), 10);
-      break;
+      const candidate = Number.parseInt(await readFile(marker, "utf8"), 10);
+      if (candidate > 1) {
+        pid = candidate;
+        break;
+      }
     } catch {
-      await new Promise((resolve) => setTimeout(resolve, 5));
+      // The detached grandchild publishes the marker asynchronously.
     }
+    await new Promise((resolve) => setTimeout(resolve, 25));
   }
   assert.ok(pid > 1, "detached fixture must publish its PID");
   assert.doesNotThrow(() => process.kill(pid, 0));

--- a/tests/e2e/assistant-scheduled-profile.spec.ts
+++ b/tests/e2e/assistant-scheduled-profile.spec.ts
@@ -35,7 +35,7 @@ test("local Assistant, Scheduled, Profile, and About surfaces stay safe to explo
   await taskSearch.fill("definitely-not-a-schedule");
   await expect(taskSearch).toHaveValue("definitely-not-a-schedule");
   await expect(page.getByText("No matching tasks", { exact: true })).toBeVisible();
-  await taskSearch.press(process.platform === "darwin" ? "Meta+A" : "Control+A");
+  await taskSearch.selectText();
   await taskSearch.press("Backspace");
   await expect(taskSearch).toHaveValue("");
   await expect(page.getByText("No matching tasks", { exact: true })).toHaveCount(0);


### PR DESCRIPTION
## Summary

- keeps polling when the marker file exists but has not received a valid PID yet
- expands the bounded wait to tolerate loaded CI runners
- preserves the detached-process containment proof and explicit cleanup

## Verification

- failing native fixture suite passed 10 consecutive runs
- `npm run type-check`
- `npm run lint`
- `git diff --check`