### PR TITLE
fix(images): harden staged artifact recovery

### DIFF
--- a/main/handlers/chats.ts
+++ b/main/handlers/chats.ts
@@ -246,7 +246,7 @@ export function registerChatHistoryHandlers(): void {
       if (!source) throw new Error("The chat is no longer available.");
       if (await displayImageArtifactStore.hasPending(parsed.chatId)) {
         throw new Error(
-          "Restart Aiden to recover the previous image response before copying this chat.",
+          "A previous image response could not be recovered. Delete this chat to discard it before copying.",
         );
       }
       const workspaceId = persistedChatWorkspaceId(source.workspaceId);
@@ -331,7 +331,7 @@ export function registerChatHistoryHandlers(): void {
       if (!chat) throw new Error("The chat is no longer available.");
       if (await displayImageArtifactStore.hasPending(chatId)) {
         throw new Error(
-          "Restart Aiden to recover the previous image response before exporting this chat.",
+          "A previous image response could not be recovered. Delete this chat to discard it before exporting.",
         );
       }
       if (owner.isDestroyed()) {
@@ -356,7 +356,7 @@ export function registerChatHistoryHandlers(): void {
       if (!latestChat) throw new Error("The chat is no longer available.");
       if (await displayImageArtifactStore.hasPending(chatId)) {
         throw new Error(
-          "Restart Aiden to recover the previous image response before exporting this chat.",
+          "A previous image response could not be recovered. Delete this chat to discard it before exporting.",
         );
       }
       if (owner.isDestroyed()) {
@@ -571,7 +571,7 @@ export function registerChatHistoryHandlers(): void {
         try {
           if (await displayImageArtifactStore.hasPending(chatId)) {
             throw new Error(
-              "Restart Aiden to recover the previous image response before sending another message.",
+              "A previous image response could not be recovered. Delete this chat to discard it before sending another message.",
             );
           }
           const authoritativeChat = skillReference

--- a/main/handlers/chats.ts
+++ b/main/handlers/chats.ts
@@ -72,9 +72,13 @@ export function registerChatHistoryHandlers(): void {
     if (llmClient.isChatOwnedByInactiveRenderer(chatId)) {
       reconciliationRequired = !(await llmClient.waitForChatIdle(chatId));
     }
+    const imageArtifactAvailability = displayImageArtifactStore.availability();
+    const imageArtifactRecoveryUnavailable = !imageArtifactAvailability.available;
     const [chat, hasStagedImageArtifact] = await Promise.all([
       chatStore.get(chatId),
-      displayImageArtifactStore.hasPending(chatId),
+      imageArtifactRecoveryUnavailable
+        ? Promise.resolve(false)
+        : displayImageArtifactStore.hasPending(chatId),
     ]);
     const imageArtifactRecoveryPending =
       hasStagedImageArtifact && !llmClient.isChatBusy(chatId)
@@ -88,6 +92,7 @@ export function registerChatHistoryHandlers(): void {
     return {
       chat: chatForRenderer(chat),
       imageArtifactRecoveryPending,
+      imageArtifactRecoveryUnavailable,
       reconciliation: reconciliationRequired
         ? {
             chatId,
@@ -245,8 +250,11 @@ export function registerChatHistoryHandlers(): void {
       const source = await chatStore.get(parsed.chatId);
       if (!source) throw new Error("The chat is no longer available.");
       if (await displayImageArtifactStore.hasPending(parsed.chatId)) {
+        const availability = displayImageArtifactStore.availability();
         throw new Error(
-          "A previous image response could not be recovered. Delete this chat to discard it before copying.",
+          availability.available
+            ? "A previous image response could not be recovered. Delete this chat to discard it before copying."
+            : `${availability.reason} Open Aiden's developer log to locate the staging file that needs repair.`,
         );
       }
       const workspaceId = persistedChatWorkspaceId(source.workspaceId);
@@ -330,8 +338,11 @@ export function registerChatHistoryHandlers(): void {
       const chat = await chatStore.get(chatId);
       if (!chat) throw new Error("The chat is no longer available.");
       if (await displayImageArtifactStore.hasPending(chatId)) {
+        const availability = displayImageArtifactStore.availability();
         throw new Error(
-          "A previous image response could not be recovered. Delete this chat to discard it before exporting.",
+          availability.available
+            ? "A previous image response could not be recovered. Delete this chat to discard it before exporting."
+            : `${availability.reason} Open Aiden's developer log to locate the staging file that needs repair.`,
         );
       }
       if (owner.isDestroyed()) {
@@ -355,8 +366,11 @@ export function registerChatHistoryHandlers(): void {
       const latestChat = await chatStore.get(chatId);
       if (!latestChat) throw new Error("The chat is no longer available.");
       if (await displayImageArtifactStore.hasPending(chatId)) {
+        const availability = displayImageArtifactStore.availability();
         throw new Error(
-          "A previous image response could not be recovered. Delete this chat to discard it before exporting.",
+          availability.available
+            ? "A previous image response could not be recovered. Delete this chat to discard it before exporting."
+            : `${availability.reason} Open Aiden's developer log to locate the staging file that needs repair.`,
         );
       }
       if (owner.isDestroyed()) {
@@ -570,8 +584,11 @@ export function registerChatHistoryHandlers(): void {
         let appended = false;
         try {
           if (await displayImageArtifactStore.hasPending(chatId)) {
+            const availability = displayImageArtifactStore.availability();
             throw new Error(
-              "A previous image response could not be recovered. Delete this chat to discard it before sending another message.",
+              availability.available
+                ? "A previous image response could not be recovered. Delete this chat to discard it before sending another message."
+                : `${availability.reason} Open Aiden's developer log to locate the staging file that needs repair.`,
             );
           }
           const authoritativeChat = skillReference

--- a/main/index.ts
+++ b/main/index.ts
@@ -1475,6 +1475,13 @@ if (!ownsSingleInstanceLock) {
       // before a renderer can read or append run history.
       await piRuntimeEffectStore.initialize();
       await displayImageArtifactStore.initialize();
+      const quarantinedImageArtifactPath = displayImageArtifactStore.quarantinedPath();
+      if (quarantinedImageArtifactPath) {
+        logger.warn(
+          "pi",
+          `Invalid image artifact staging was preserved at ${quarantinedImageArtifactPath}; Aiden opened a clean staging store.`,
+        );
+      }
       const displayImageArtifactAvailability = displayImageArtifactStore.availability();
       if (!displayImageArtifactAvailability.available) {
         logger.warn(

--- a/main/index.ts
+++ b/main/index.ts
@@ -1475,38 +1475,58 @@ if (!ownsSingleInstanceLock) {
       // before a renderer can read or append run history.
       await piRuntimeEffectStore.initialize();
       await displayImageArtifactStore.initialize();
+      const displayImageArtifactAvailability = displayImageArtifactStore.availability();
+      if (!displayImageArtifactAvailability.available) {
+        logger.warn(
+          "pi",
+          "Image artifact recovery is unavailable; chat mutations will remain blocked.",
+          new Error(displayImageArtifactAvailability.reason),
+        );
+      }
       await subagentRunStore.initialize();
       await reconcilePendingChatDeletions(subagentRunStore, async (chatId) => {
-        await displayImageArtifactStore.deleteChat(chatId);
+        if (displayImageArtifactAvailability.available) {
+          await displayImageArtifactStore.deleteChat(chatId);
+        }
         await piRuntimeEffectStore.deleteChat(chatId);
         await piCompactionSessionStore.deleteChat(chatId);
         await chatStore.remove(chatId);
       });
-      const startupChats = (
-        await Promise.all(
-          (await displayImageArtifactStore.pendingChatIds()).map((chatId) =>
-            chatStore.get(chatId),
-          ),
-        )
-      ).filter((chat): chat is Chat => chat !== null);
-      await displayImageArtifactStore.recover(
-        startupChats,
-        async ({ chatId, attachments, createdAt, model }) => {
-          await chatStore.appendMessage(chatId, {
-            role: "assistant",
-            content: "",
-            attachments,
-            createdAt,
-            model,
-            providerFailure: {
-              version: 1,
-              category: "interrupted",
-              attempts: 1,
-              retryExhausted: false,
+      if (displayImageArtifactAvailability.available) {
+        try {
+          const startupChats = (
+            await Promise.all(
+              (await displayImageArtifactStore.pendingChatIds()).map((chatId) =>
+                chatStore.get(chatId),
+              ),
+            )
+          ).filter((chat): chat is Chat => chat !== null);
+          await displayImageArtifactStore.recover(
+            startupChats,
+            async ({ chatId, attachments, createdAt, model }) => {
+              await chatStore.appendMessage(chatId, {
+                role: "assistant",
+                content: "",
+                attachments,
+                createdAt,
+                model,
+                providerFailure: {
+                  version: 1,
+                  category: "interrupted",
+                  attempts: 1,
+                  retryExhausted: false,
+                },
+              });
             },
-          });
-        },
-      );
+          );
+        } catch (error) {
+          logger.warn(
+            "pi",
+            "Could not recover staged image artifacts; affected chats remain blocked.",
+            error,
+          );
+        }
+      }
       const visibleChatIds = new Set(
         (await chatStore.list()).map((chat) => chat.id),
       );

--- a/main/services/display-image-artifact-store.test.ts
+++ b/main/services/display-image-artifact-store.test.ts
@@ -351,6 +351,7 @@ test("main blocks new sends and copies until staged artifacts are recovered", as
   assert.match(handlers, /displayImageArtifactStore\.hasPending\(chatId\)/u);
   assert.match(handlers, /displayImageArtifactStore\.hasPending\(parsed\.chatId\)/u);
   assert.match(handlers, /Delete this chat to discard it/iu);
+  assert.match(handlers, /developer log to locate the staging file that needs repair/iu);
   const exportHandler = handlers.slice(handlers.indexOf('ipcMain.handle("chats:export"'));
   assert.match(exportHandler, /displayImageArtifactStore\.hasPending\(chatId\)/u);
   const readHandler = handlers.slice(

--- a/main/services/display-image-artifact-store.test.ts
+++ b/main/services/display-image-artifact-store.test.ts
@@ -116,6 +116,66 @@ test("staging is idempotent and pending usage remains chat-scoped", async () => 
   });
 });
 
+test("pending usage projections do not clone staged image payloads", async () => {
+  const root = await storageRoot();
+  const store = new DisplayImageArtifactStore({ root: () => root });
+  await store.initialize();
+  await store.stage({
+    chatId: "chat-1",
+    generationId: "generation-1",
+    artifact: artifact("image-1"),
+    pixels: 1,
+  });
+  const structuredCloneDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "structuredClone",
+  );
+  Object.defineProperty(globalThis, "structuredClone", {
+    configurable: true,
+    writable: true,
+    value: () => {
+      throw new Error("usage queries must not clone payloads");
+    },
+  });
+  try {
+    assert.deepEqual(await store.usageByChat("chat-1"), {
+      bytes: ONE_PIXEL_PNG.length,
+      count: 1,
+      pixels: 1,
+    });
+    assert.equal(await store.hasPending("chat-1"), true);
+  } finally {
+    if (structuredCloneDescriptor) {
+      Object.defineProperty(globalThis, "structuredClone", structuredCloneDescriptor);
+    }
+  }
+});
+
+test("unreadable staging degrades without aborting initialization", async () => {
+  const root = await storageRoot();
+  const file = path.join(root, "display-image-artifacts.json");
+  await fs.writeFile(file, "{", "utf8");
+  const store = new DisplayImageArtifactStore({ root: () => root });
+
+  await store.initialize();
+
+  assert.deepEqual(store.availability(), {
+    available: false,
+    reason: "Display-image artifact staging is unreadable and was preserved.",
+  });
+  assert.equal(await store.hasPending("chat-1"), true);
+  await assert.rejects(
+    store.stage({
+      chatId: "chat-1",
+      generationId: "generation-1",
+      artifact: artifact("image-1"),
+      pixels: 1,
+    }),
+    /unreadable and was preserved/iu,
+  );
+  assert.equal(await fs.readFile(file, "utf8"), "{");
+});
+
 test("startup recovery retains the only durable copy when chat storage is unresolved", async () => {
   const root = await storageRoot();
   const store = new DisplayImageArtifactStore({ root: () => root });
@@ -296,4 +356,6 @@ test("startup marks crash-recovered image generations as interrupted", async () 
   const recovery = index.slice(index.indexOf("displayImageArtifactStore.recover("));
   assert.match(recovery, /category: "interrupted"/u);
   assert.match(recovery, /attachments,/u);
+  assert.match(recovery, /Could not recover staged image artifacts/iu);
+  assert.match(recovery, /affected chats remain blocked/iu);
 });

--- a/main/services/display-image-artifact-store.test.ts
+++ b/main/services/display-image-artifact-store.test.ts
@@ -151,7 +151,7 @@ test("pending usage projections do not clone staged image payloads", async () =>
   }
 });
 
-test("unreadable staging degrades without aborting initialization", async () => {
+test("unreadable staging is quarantined without blocking unrelated chats", async () => {
   const root = await storageRoot();
   const file = path.join(root, "display-image-artifacts.json");
   await fs.writeFile(file, "{", "utf8");
@@ -159,21 +159,36 @@ test("unreadable staging degrades without aborting initialization", async () => 
 
   await store.initialize();
 
-  assert.deepEqual(store.availability(), {
-    available: false,
-    reason: "Display-image artifact staging is unreadable and was preserved.",
+  assert.deepEqual(store.availability(), { available: true });
+  assert.equal(await store.hasPending("chat-1"), false);
+  const preserved = store.quarantinedPath();
+  assert.ok(preserved);
+  assert.ok(preserved.startsWith(`${file}.invalid-`));
+  assert.equal(await fs.readFile(preserved, "utf8"), "{");
+  await store.stage({
+    chatId: "chat-1",
+    generationId: "generation-1",
+    artifact: artifact("image-1"),
+    pixels: 1,
   });
   assert.equal(await store.hasPending("chat-1"), true);
-  await assert.rejects(
-    store.stage({
-      chatId: "chat-1",
-      generationId: "generation-1",
-      artifact: artifact("image-1"),
-      pixels: 1,
-    }),
-    /unreadable and was preserved/iu,
-  );
-  assert.equal(await fs.readFile(file, "utf8"), "{");
+  assert.doesNotMatch(await fs.readFile(file, "utf8"), /^\{$/u);
+});
+
+test("unsupported staging is quarantined before a clean store is opened", async () => {
+  const root = await storageRoot();
+  const file = path.join(root, "display-image-artifacts.json");
+  const unsupported = JSON.stringify({ version: 99, records: [] });
+  await fs.writeFile(file, unsupported, "utf8");
+  const store = new DisplayImageArtifactStore({ root: () => root });
+
+  await store.initialize();
+
+  assert.deepEqual(store.availability(), { available: true });
+  assert.equal(await store.hasPending("chat-1"), false);
+  const preserved = store.quarantinedPath();
+  assert.ok(preserved);
+  assert.equal(await fs.readFile(preserved, "utf8"), unsupported);
 });
 
 test("startup recovery retains the only durable copy when chat storage is unresolved", async () => {
@@ -335,7 +350,7 @@ test("main blocks new sends and copies until staged artifacts are recovered", as
   );
   assert.match(handlers, /displayImageArtifactStore\.hasPending\(chatId\)/u);
   assert.match(handlers, /displayImageArtifactStore\.hasPending\(parsed\.chatId\)/u);
-  assert.match(handlers, /Restart Aiden to recover the previous image response/iu);
+  assert.match(handlers, /Delete this chat to discard it/iu);
   const exportHandler = handlers.slice(handlers.indexOf('ipcMain.handle("chats:export"'));
   assert.match(exportHandler, /displayImageArtifactStore\.hasPending\(chatId\)/u);
   const readHandler = handlers.slice(

--- a/main/services/display-image-artifact-store.ts
+++ b/main/services/display-image-artifact-store.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { DataStore } from "./data-store.js";
 import type { Attachment } from "./types.js";
 import { parseChatArtifactV1, type ChatArtifactV1 } from "../../renderer/shared/chat-artifacts.js";
@@ -199,23 +201,56 @@ function stagedUsage(records: readonly StagedDisplayImageArtifact[]): DisplayIma
 
 /** Durable payload staging for non-replayable display effects. */
 export class DisplayImageArtifactStore {
-  private readonly data: DataStore<DisplayImageArtifactDatabase>;
+  private data: DataStore<DisplayImageArtifactDatabase>;
+  private readonly options: DisplayImageArtifactStoreOptions;
+  private readonly ownsDataStore: boolean;
   private readonly now: () => number;
   private initialized = false;
   private unavailableReason: string | null = null;
+  private quarantinedStorePath: string | null = null;
 
   constructor(options: DisplayImageArtifactStoreOptions = {}) {
+    this.options = options;
+    this.ownsDataStore = options.dataStore === undefined;
     this.data = options.dataStore ?? createDataStore(options);
     this.now = options.now ?? Date.now;
+  }
+
+  private async quarantineInvalidStore(reason: string): Promise<boolean> {
+    if (!this.ownsDataStore) return false;
+    const source = await this.data.path();
+    const stamp = new Date(this.now()).toISOString().replace(/[:.]/gu, "-");
+    const preserved = `${source}.invalid-${stamp}-${randomUUID()}`;
+    try {
+      await fs.rename(source, preserved);
+      const replacement = createDataStore(this.options);
+      await replacement.load();
+      if (
+        (await replacement.loadedFromCorruptFile()) ||
+        (await replacement.loadedFromUnsafeFile())
+      ) {
+        throw new Error("The replacement display-image artifact store is unavailable.");
+      }
+      this.data = replacement;
+      this.quarantinedStorePath = preserved;
+      return true;
+    } catch (error) {
+      this.unavailableReason = `${reason} Aiden could not preserve it at ${preserved}: ${error instanceof Error ? error.message : String(error)}`;
+      return false;
+    }
   }
 
   async initialize(): Promise<void> {
     if (this.initialized) return;
     await this.data.load();
+    let unavailableReason: string | null = null;
     if (await this.data.loadedFromCorruptFile()) {
-      this.unavailableReason = "Display-image artifact staging is unreadable and was preserved.";
+      unavailableReason = "Display-image artifact staging is unreadable.";
     } else if (await this.data.loadedFromUnsafeFile()) {
-      this.unavailableReason = "Display-image artifact staging has an unsupported shape.";
+      unavailableReason = "Display-image artifact staging has an unsupported shape.";
+    }
+    if (unavailableReason && !(await this.quarantineInvalidStore(unavailableReason))) {
+      this.unavailableReason ??= unavailableReason;
     }
     this.initialized = true;
   }
@@ -229,6 +264,11 @@ export class DisplayImageArtifactStore {
     return this.unavailableReason
       ? { available: false, reason: this.unavailableReason }
       : { available: true };
+  }
+
+  quarantinedPath(): string | null {
+    this.requireInitialized();
+    return this.quarantinedStorePath;
   }
 
   private requireAvailable(): void {

--- a/main/services/display-image-artifact-store.ts
+++ b/main/services/display-image-artifact-store.ts
@@ -235,7 +235,7 @@ export class DisplayImageArtifactStore {
       this.quarantinedStorePath = preserved;
       return true;
     } catch (error) {
-      this.unavailableReason = `${reason} Aiden could not preserve it at ${preserved}: ${error instanceof Error ? error.message : String(error)}`;
+      this.unavailableReason = `${reason} Aiden could not move ${source} to ${preserved}: ${error instanceof Error ? error.message : String(error)}`;
       return false;
     }
   }

--- a/main/services/display-image-artifact-store.ts
+++ b/main/services/display-image-artifact-store.ts
@@ -202,6 +202,7 @@ export class DisplayImageArtifactStore {
   private readonly data: DataStore<DisplayImageArtifactDatabase>;
   private readonly now: () => number;
   private initialized = false;
+  private unavailableReason: string | null = null;
 
   constructor(options: DisplayImageArtifactStoreOptions = {}) {
     this.data = options.dataStore ?? createDataStore(options);
@@ -212,16 +213,27 @@ export class DisplayImageArtifactStore {
     if (this.initialized) return;
     await this.data.load();
     if (await this.data.loadedFromCorruptFile()) {
-      throw new Error("Display-image artifact staging is unreadable and was preserved.");
-    }
-    if (await this.data.loadedFromUnsafeFile()) {
-      throw new Error("Display-image artifact staging has an unsupported shape.");
+      this.unavailableReason = "Display-image artifact staging is unreadable and was preserved.";
+    } else if (await this.data.loadedFromUnsafeFile()) {
+      this.unavailableReason = "Display-image artifact staging has an unsupported shape.";
     }
     this.initialized = true;
   }
 
   private requireInitialized(): void {
     if (!this.initialized) throw new Error("Display-image artifact staging is not initialized.");
+  }
+
+  availability(): { available: true } | { available: false; reason: string } {
+    this.requireInitialized();
+    return this.unavailableReason
+      ? { available: false, reason: this.unavailableReason }
+      : { available: true };
+  }
+
+  private requireAvailable(): void {
+    this.requireInitialized();
+    if (this.unavailableReason) throw new Error(this.unavailableReason);
   }
 
   async stage(input: {
@@ -231,7 +243,7 @@ export class DisplayImageArtifactStore {
     artifact: ChatArtifactV1;
     pixels: number;
   }): Promise<"inserted" | "existing"> {
-    this.requireInitialized();
+    this.requireAvailable();
     const parsed = parseRecord({
       version: STORE_VERSION,
       ...input,
@@ -274,7 +286,7 @@ export class DisplayImageArtifactStore {
   }
 
   async remove(chatId: string, artifactIds: readonly string[]): Promise<void> {
-    this.requireInitialized();
+    this.requireAvailable();
     if (!boundedIdentity(chatId) || artifactIds.some((id) => !boundedIdentity(id))) {
       throw new Error("Invalid display-image artifact cleanup identity.");
     }
@@ -290,7 +302,7 @@ export class DisplayImageArtifactStore {
   }
 
   async deleteChat(chatId: string): Promise<void> {
-    this.requireInitialized();
+    this.requireAvailable();
     if (!boundedIdentity(chatId)) return;
     await this.data.update((database) => {
       const before = database.records.length;
@@ -300,7 +312,7 @@ export class DisplayImageArtifactStore {
   }
 
   async pending(): Promise<readonly StagedDisplayImageArtifact[]> {
-    this.requireInitialized();
+    this.requireAvailable();
     return structuredClone((await this.data.load()).records);
   }
 
@@ -309,12 +321,15 @@ export class DisplayImageArtifactStore {
   }
 
   async usageByChat(chatId: string): Promise<DisplayImageArtifactUsage> {
-    this.requireInitialized();
+    this.requireAvailable();
     if (!boundedIdentity(chatId)) throw new Error("Invalid display-image artifact chat identity.");
-    return stagedUsage((await this.pending()).filter((record) => record.chatId === chatId));
+    return stagedUsage((await this.data.load()).records.filter((record) => record.chatId === chatId));
   }
 
   async hasPending(chatId: string): Promise<boolean> {
+    this.requireInitialized();
+    if (!boundedIdentity(chatId)) throw new Error("Invalid display-image artifact chat identity.");
+    if (this.unavailableReason) return true;
     const usage = await this.usageByChat(chatId);
     return usage.count > 0;
   }
@@ -324,7 +339,7 @@ export class DisplayImageArtifactStore {
     chats: readonly DisplayImageArtifactRecoveryChat[],
     append: (message: RecoveredDisplayImageMessage) => Promise<void>,
   ): Promise<void> {
-    this.requireInitialized();
+    this.requireAvailable();
     const chatById = new Map(chats.map((chat) => [chat.id, chat]));
     const records = await this.pending();
     const recordsByChat = new Map<string, StagedDisplayImageArtifact[]>();

--- a/main/services/llm-client.ts
+++ b/main/services/llm-client.ts
@@ -708,7 +708,9 @@ async function prepareGeneration(
     const existingUsage = displayedAssistantImageUsage(chat.messages);
     const pendingUsage = await displayImageArtifactStore.usageByChat(params.chatId);
     if (pendingUsage.count > 0) {
-      throw new Error("Restart Aiden to recover the previous image response before continuing.");
+      throw new Error(
+        "A previous image response could not be recovered. Delete this chat to discard it before continuing.",
+      );
     }
     const displayImageRuntime = createDisplayImageExtensionRuntime({
       workspaceRoot: folderPath!,

--- a/main/services/llm-client.ts
+++ b/main/services/llm-client.ts
@@ -705,6 +705,12 @@ async function prepareGeneration(
       excluded: options.excludeToolNames?.has(DISPLAY_IMAGE_TOOL_NAME) ?? false,
     })
   ) {
+    const artifactStoreAvailability = displayImageArtifactStore.availability();
+    if (!artifactStoreAvailability.available) {
+      throw new Error(
+        `${artifactStoreAvailability.reason} Open Aiden's developer log to locate the staging file that needs repair.`,
+      );
+    }
     const existingUsage = displayedAssistantImageUsage(chat.messages);
     const pendingUsage = await displayImageArtifactStore.usageByChat(params.chatId);
     if (pendingUsage.count > 0) {

--- a/renderer/lib/chat-terminal-sync.test.ts
+++ b/renderer/lib/chat-terminal-sync.test.ts
@@ -351,6 +351,7 @@ test("a provisional stale read survives a missed settlement event until authorit
   const response = parseChatReadResponse({
     chat: stale,
     imageArtifactRecoveryPending: false,
+    imageArtifactRecoveryUnavailable: false,
     reconciliation: {
       chatId: stale.id,
       workspaceId: stale.workspaceId,
@@ -405,11 +406,27 @@ test("chat read reconciliation metadata is bounded, content-free, and owner-boun
     parseChatReadResponse({
       chat: stale,
       imageArtifactRecoveryPending: true,
+      imageArtifactRecoveryUnavailable: false,
       reconciliation: null,
     }),
     {
       chat: stale,
       imageArtifactRecoveryPending: true,
+      imageArtifactRecoveryUnavailable: false,
+      reconciliation: null,
+    },
+  );
+  assert.deepEqual(
+    parseChatReadResponse({
+      chat: stale,
+      imageArtifactRecoveryPending: false,
+      imageArtifactRecoveryUnavailable: true,
+      reconciliation: null,
+    }),
+    {
+      chat: stale,
+      imageArtifactRecoveryPending: false,
+      imageArtifactRecoveryUnavailable: true,
       reconciliation: null,
     },
   );
@@ -418,16 +435,19 @@ test("chat read reconciliation metadata is bounded, content-free, and owner-boun
     {
       chat: stale,
       imageArtifactRecoveryPending: false,
+      imageArtifactRecoveryUnavailable: false,
       reconciliation: { chatId: "chat-b", workspaceId: "workspace-1" },
     },
     {
       chat: stale,
       imageArtifactRecoveryPending: false,
+      imageArtifactRecoveryUnavailable: false,
       reconciliation: { chatId: "chat-a", workspaceId: "/private/path" },
     },
     {
       chat: stale,
       imageArtifactRecoveryPending: false,
+      imageArtifactRecoveryUnavailable: false,
       reconciliation: {
         chatId: "chat-a",
         workspaceId: "x".repeat(500),

--- a/renderer/lib/chat-terminal-sync.ts
+++ b/renderer/lib/chat-terminal-sync.ts
@@ -129,7 +129,8 @@ export function parseChatReadResponse(payload: unknown): ChatReadResponse | null
   const candidate = payload as Record<string, unknown>;
   if (
     (candidate.chat !== null && !isChatSnapshot(candidate.chat)) ||
-    typeof candidate.imageArtifactRecoveryPending !== "boolean"
+    typeof candidate.imageArtifactRecoveryPending !== "boolean" ||
+    typeof candidate.imageArtifactRecoveryUnavailable !== "boolean"
   ) {
     return null;
   }
@@ -137,6 +138,7 @@ export function parseChatReadResponse(payload: unknown): ChatReadResponse | null
     return {
       chat: candidate.chat as Chat | null,
       imageArtifactRecoveryPending: candidate.imageArtifactRecoveryPending,
+      imageArtifactRecoveryUnavailable: candidate.imageArtifactRecoveryUnavailable,
       reconciliation: null,
     };
   }
@@ -158,6 +160,7 @@ export function parseChatReadResponse(payload: unknown): ChatReadResponse | null
   return {
     chat: candidate.chat as Chat | null,
     imageArtifactRecoveryPending: candidate.imageArtifactRecoveryPending,
+    imageArtifactRecoveryUnavailable: candidate.imageArtifactRecoveryUnavailable,
     reconciliation: {
       chatId: reconciliation.chatId,
       workspaceId: persistedChatWorkspaceId(reconciliation.workspaceId),

--- a/renderer/lib/ipc.ts
+++ b/renderer/lib/ipc.ts
@@ -632,6 +632,7 @@ export const chatsApi = {
       ? {
           ...response.chat,
           imageArtifactRecoveryPending: response.imageArtifactRecoveryPending,
+          imageArtifactRecoveryUnavailable: response.imageArtifactRecoveryUnavailable,
         }
       : null;
   },

--- a/renderer/lib/types.ts
+++ b/renderer/lib/types.ts
@@ -485,6 +485,8 @@ export interface Chat extends ChatMeta {
   computerUseEnabled?: boolean;
   /** Main-owned crash stage exists and must be recovered before another chat mutation. */
   imageArtifactRecoveryPending?: boolean;
+  /** Main-owned image staging could not be opened or quarantined automatically. */
+  imageArtifactRecoveryUnavailable?: boolean;
   messages: ChatMessage[];
 }
 
@@ -495,6 +497,7 @@ export interface Chat extends ChatMeta {
 export interface ChatReadResponse {
   chat: Chat | null;
   imageArtifactRecoveryPending: boolean;
+  imageArtifactRecoveryUnavailable: boolean;
   reconciliation: {
     chatId: string;
     workspaceId: string;

--- a/renderer/main/chat-pane.tsx
+++ b/renderer/main/chat-pane.tsx
@@ -374,6 +374,8 @@ export function ChatPane({ chatId }: { chatId: string }) {
   const hasMessages = messages.length > 0;
   const imageArtifactRecoveryPending =
     hasUnpersistedResponse || chat.data?.imageArtifactRecoveryPending === true;
+  const imageArtifactRecoveryUnavailable =
+    chat.data?.imageArtifactRecoveryUnavailable === true;
   const isGenerating = streamingText !== null && !hasUnpersistedResponse;
   const isNewChat = !chat.isLoading && !hasMessages && !isGenerating;
 
@@ -392,6 +394,11 @@ export function ChatPane({ chatId }: { chatId: string }) {
     async (throughAssistantMessageId?: string) => {
       if (documentAppendReconciliationRequired) {
         throw new Error("Reload Aiden before copying this chat.");
+      }
+      if (imageArtifactRecoveryUnavailable) {
+        throw new Error(
+          "Image response staging is unavailable. Open Aiden's developer log to locate the staging file that needs repair.",
+        );
       }
       if (imageArtifactRecoveryPending) {
         throw new Error(
@@ -434,6 +441,7 @@ export function ChatPane({ chatId }: { chatId: string }) {
       chatId,
       documentAppendReconciliationRequired,
       imageArtifactRecoveryPending,
+      imageArtifactRecoveryUnavailable,
       isGenerating,
       isStartingGeneration,
       navigate,
@@ -794,6 +802,11 @@ export function ChatPane({ chatId }: { chatId: string }) {
 
   const handleSend = React.useCallback(
     async (text: string, attachments: Attachment[], skillInvocation?: SkillInvocationV1) => {
+      if (imageArtifactRecoveryUnavailable) {
+        throw new Error(
+          "Image response staging is unavailable. Open Aiden's developer log to locate the staging file that needs repair.",
+        );
+      }
       if (imageArtifactRecoveryPending) {
         throw new Error(
           "A previous image response could not be recovered. Delete this chat to discard it before sending another message.",
@@ -866,6 +879,7 @@ export function ChatPane({ chatId }: { chatId: string }) {
       computerUseSaving,
       detachedGenerationDraining,
       imageArtifactRecoveryPending,
+      imageArtifactRecoveryUnavailable,
       providerId,
       model,
       qc,
@@ -1506,9 +1520,13 @@ export function ChatPane({ chatId }: { chatId: string }) {
             // route no longer remounts the pane, and Composer owns that text
             // without a chatId reset of its own.
             key={chatId}
-            ready={ready && !imageArtifactRecoveryPending}
+            ready={
+              ready && !imageArtifactRecoveryPending && !imageArtifactRecoveryUnavailable
+            }
             readinessMessage={
-              imageArtifactRecoveryPending
+              imageArtifactRecoveryUnavailable
+                ? "Image response staging is unavailable. Open Aiden's developer log to locate the staging file that needs repair."
+                : imageArtifactRecoveryPending
                 ? "An image response could not be recovered. Delete this chat to discard it before sending another message."
                 : readinessMessage
             }
@@ -1563,6 +1581,8 @@ export function ChatPane({ chatId }: { chatId: string }) {
             slashSessionBlockedReason={
               documentAppendReconciliationRequired
                 ? "Reload Aiden before copying this chat."
+                : imageArtifactRecoveryUnavailable
+                  ? "Open Aiden's developer log to locate the image staging file that needs repair."
                 : imageArtifactRecoveryPending
                   ? "Delete this chat to discard the unrecovered image response before copying."
                   : undefined
@@ -1667,9 +1687,11 @@ export function ChatPane({ chatId }: { chatId: string }) {
           agentActivity={visibleAgentActivity}
           error={
             error ??
-            (imageArtifactRecoveryPending
-              ? "An image response could not be recovered. Delete this chat to discard it before continuing."
-              : null)
+            (imageArtifactRecoveryUnavailable
+              ? "Image response staging is unavailable. Open Aiden's developer log to locate the staging file that needs repair."
+              : imageArtifactRecoveryPending
+                ? "An image response could not be recovered. Delete this chat to discard it before continuing."
+                : null)
           }
         />
       )}

--- a/renderer/main/chat-pane.tsx
+++ b/renderer/main/chat-pane.tsx
@@ -394,7 +394,9 @@ export function ChatPane({ chatId }: { chatId: string }) {
         throw new Error("Reload Aiden before copying this chat.");
       }
       if (imageArtifactRecoveryPending) {
-        throw new Error("Restart Aiden to recover this image response before copying the chat.");
+        throw new Error(
+          "A previous image response could not be recovered. Delete this chat to discard it before copying.",
+        );
       }
       if (isGenerating || isStartingGeneration || approvals.length > 0) {
         throw new Error("Finish the current response or approval before copying this chat.");
@@ -794,7 +796,7 @@ export function ChatPane({ chatId }: { chatId: string }) {
     async (text: string, attachments: Attachment[], skillInvocation?: SkillInvocationV1) => {
       if (imageArtifactRecoveryPending) {
         throw new Error(
-          "Restart Aiden to recover the previous image response before sending another message.",
+          "A previous image response could not be recovered. Delete this chat to discard it before sending another message.",
         );
       }
       if (computerUseSaving) {
@@ -1507,7 +1509,7 @@ export function ChatPane({ chatId }: { chatId: string }) {
             ready={ready && !imageArtifactRecoveryPending}
             readinessMessage={
               imageArtifactRecoveryPending
-                ? "Response save failed. Restart Aiden to recover it before sending another message."
+                ? "An image response could not be recovered. Delete this chat to discard it before sending another message."
                 : readinessMessage
             }
             hasMessages={hasMessages}
@@ -1562,7 +1564,7 @@ export function ChatPane({ chatId }: { chatId: string }) {
               documentAppendReconciliationRequired
                 ? "Reload Aiden before copying this chat."
                 : imageArtifactRecoveryPending
-                  ? "Restart Aiden to recover this image response before copying the chat."
+                  ? "Delete this chat to discard the unrecovered image response before copying."
                   : undefined
             }
             slashPaletteBlocked={Boolean(pending)}
@@ -1666,7 +1668,7 @@ export function ChatPane({ chatId }: { chatId: string }) {
           error={
             error ??
             (imageArtifactRecoveryPending
-              ? "Response save failed. Restart Aiden to recover the displayed image before continuing."
+              ? "An image response could not be recovered. Delete this chat to discard it before continuing."
               : null)
           }
         />

--- a/renderer/main/chat-transition.test.tsx
+++ b/renderer/main/chat-transition.test.tsx
@@ -156,8 +156,13 @@ test("an unpersisted image response blocks sends, copies, and the composer until
     pane,
     /hasUnpersistedResponse \|\| chat\.data\?\.imageArtifactRecoveryPending === true/u,
   );
-  assert.match(pane, /ready=\{ready && !imageArtifactRecoveryPending\}/u);
+  assert.match(
+    pane,
+    /ready=\{\s*ready && !imageArtifactRecoveryPending && !imageArtifactRecoveryUnavailable\s*\}/u,
+  );
   assert.match(pane, /Delete this chat to discard it/iu);
+  assert.match(pane, /imageArtifactRecoveryUnavailable/u);
+  assert.match(pane, /developer log to locate the staging file that needs repair/iu);
 });
 
 test("terminal chat snapshots reach cache before visual stream handoff awaits", () => {

--- a/renderer/main/chat-transition.test.tsx
+++ b/renderer/main/chat-transition.test.tsx
@@ -141,7 +141,7 @@ test("a committed append is not presented as unsent when generation start later 
   assert.doesNotMatch(handleSend, /if \(!started\.ok\) throw/u);
 });
 
-test("an unpersisted image response blocks sends, copies, and the composer until restart", () => {
+test("an unpersisted image response blocks sends, copies, and the composer until deletion", () => {
   const pane = source("./chat-pane.tsx");
   const handleSend = between(
     pane,
@@ -157,7 +157,7 @@ test("an unpersisted image response blocks sends, copies, and the composer until
     /hasUnpersistedResponse \|\| chat\.data\?\.imageArtifactRecoveryPending === true/u,
   );
   assert.match(pane, /ready=\{ready && !imageArtifactRecoveryPending\}/u);
-  assert.match(pane, /Response save failed\. Restart Aiden to recover it/iu);
+  assert.match(pane, /Delete this chat to discard it/iu);
 });
 
 test("terminal chat snapshots reach cache before visual stream handoff awaits", () => {


### PR DESCRIPTION
## Summary

Addresses the remaining actionable review findings from #36.

- degrades unreadable/unsafe artifact staging without aborting application startup
- keeps chat mutations blocked when staging is unavailable
- catches recovery-limit failures while retaining staged payloads for repair
- computes pending usage from cached metadata without cloning base64 image payloads

## Verification

- `npx tsx --test main/services/display-image-artifact-store.test.ts` — 12 passed
- `npm run type-check`
- `npm run lint`
- `git diff --check`