### PR TITLE
fix(release): publish Electron 0.31.0 and document TestFlight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          release_version="$(node scripts/prepare-ci-release.mjs "$GITHUB_RUN_NUMBER")"
-          npm version "$release_version" --no-git-tag-version
+          base_version="$(node -p "require('./package.json').version")"
+          base_tag_match="$(git ls-remote --tags origin "refs/tags/v${base_version}")"
+          base_tag_exists=false
+          if [[ -n "$base_tag_match" ]]; then
+            base_tag_exists=true
+          fi
+          release_version="$(node scripts/prepare-ci-release.mjs "$GITHUB_RUN_NUMBER" "$base_tag_exists")"
+          npm version "$release_version" --no-git-tag-version --allow-same-version
           echo "version=$release_version" >> "$GITHUB_OUTPUT"
           echo "tag=v$release_version" >> "$GITHUB_OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ npm run dev
 
 The native Aiden On The Go iPhone and iPad client lives in [`ios/`](ios/README.md). It is not part of the Electron development command; open `ios/AidenOnTheGo.xcodeproj` or use the documented physical-device `xcodebuild` commands separately.
 
+### Mobile distribution
+
+The iPhone and iPad app is distributed through **TestFlight only**. GitHub releases do not publish an IPA; [`ios/README.md`](ios/README.md) documents local development and device validation. Android validation builds remain separate from the macOS release and are uploaded by CI as installable APK artifacts.
+
 The development launcher prepares a cached, ad-hoc-signed **Aiden Agent Dev** runtime that can run beside the installed **Aiden Agent** app. Development uses separate Application Support, Chromium session, log, crash, and `~/.aiden-dev` roots; it does not copy production data, register global shortcuts, or check the production update feed by default. Set `AIDEN_DEV_GLOBAL_SHORTCUTS=1` only when a development run intentionally needs the global bindings.
 
 Native builds discover the newest compatible full Xcode without changing the machine-wide `xcode-select` setting; `DEVELOPER_DIR` remains available as a per-command override.

--- a/main/services/computer-use/computer-use-foundation.test.ts
+++ b/main/services/computer-use/computer-use-foundation.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter, getEventListeners } from "node:events";
-import { mkdir, mkdtemp, readFile, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, symlink } from "node:fs/promises";
 import os from "node:os";
 import { createConnection } from "node:net";
 import path from "node:path";
@@ -955,10 +955,8 @@ test("one startup deadline aborts bridge verification and cleans up the launch l
     const broker = events.find((event) => event.event === "spawn" && event.command === "broker");
     assert.equal(typeof broker?.pid, "number");
     assertProcessExited(broker?.pid as number);
-    assert.equal(
-      events.some((event) => event.event === "broker-launch-lease-connected"),
-      true,
-    );
+    const leftovers = (await readdir(root)).filter((name) => name !== path.basename(logPath));
+    assert.deepEqual(leftovers, [], "deadline cleanup should remove the launch lease directory");
   } finally {
     await host.shutdown();
     await rm(root, { recursive: true, force: true });

--- a/scripts/prepare-ci-release.mjs
+++ b/scripts/prepare-ci-release.mjs
@@ -16,7 +16,25 @@ export function automaticReleaseVersion(baseVersion, runNumber) {
   return `${Number(match[1])}.${Number(match[2])}.${Number(runNumber)}`;
 }
 
+export function mainPushReleaseVersion(baseVersion, runNumber, baseTagExists) {
+  const incrementedVersion = automaticReleaseVersion(baseVersion, runNumber);
+  if (typeof baseTagExists !== "boolean") {
+    throw new Error("Base tag existence must be a boolean");
+  }
+  return baseTagExists ? incrementedVersion : baseVersion;
+}
+
 if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
   const packageJson = JSON.parse(await readFile(path.join(repositoryRoot, "package.json"), "utf8"));
-  console.log(automaticReleaseVersion(packageJson.version, process.argv[2]));
+  const baseTagExistsArgument = process.argv[3];
+  if (baseTagExistsArgument !== "true" && baseTagExistsArgument !== "false") {
+    throw new Error("Base tag existence must be provided as true or false");
+  }
+  console.log(
+    mainPushReleaseVersion(
+      packageJson.version,
+      process.argv[2],
+      baseTagExistsArgument === "true",
+    ),
+  );
 }

--- a/scripts/prepare-ci-release.test.mjs
+++ b/scripts/prepare-ci-release.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { automaticReleaseVersion } from "./prepare-ci-release.mjs";
+import {
+  automaticReleaseVersion,
+  mainPushReleaseVersion,
+} from "./prepare-ci-release.mjs";
 
 test("main pushes receive a monotonic patch version inside the declared release line", () => {
   assert.equal(automaticReleaseVersion("0.27.0", "41"), "0.27.41");
@@ -13,4 +16,16 @@ test("automatic release versions reject ambiguous inputs", () => {
   assert.throws(() => automaticReleaseVersion("1.0", 1), /Invalid base release version/u);
   assert.throws(() => automaticReleaseVersion("1.0.0", 0), /positive integer/u);
   assert.throws(() => automaticReleaseVersion("1.0.0", "01"), /positive integer/u);
+});
+
+test("a declared version publishes exactly once before automatic build increments", () => {
+  assert.equal(mainPushReleaseVersion("0.31.0", 55, false), "0.31.0");
+  assert.equal(mainPushReleaseVersion("0.31.0", 56, true), "0.31.56");
+});
+
+test("main-push release selection requires an explicit tag state", () => {
+  assert.throws(
+    () => mainPushReleaseVersion("0.31.0", 55, undefined),
+    /Base tag existence must be a boolean/u,
+  );
 });

--- a/scripts/run-macos-distribution.test.mjs
+++ b/scripts/run-macos-distribution.test.mjs
@@ -183,6 +183,8 @@ test("release publication checks deployed consumers before building", async () =
   const consumerCheck = workflow.indexOf("npm run release:check-consumers");
   const distributionBuild = workflow.indexOf("npm run dist");
 
+  assert.match(workflow, /git ls-remote --tags origin/u);
+  assert.match(workflow, /--allow-same-version/u);
   assert.ok(consumerCheck >= 0, "the release workflow must check Homebrew and the website");
   assert.ok(
     distributionBuild > consumerCheck,


### PR DESCRIPTION
## Summary
- publish the declared Electron version exactly when its tag is still available, then use monotonic CI patches for later main pushes in the same line
- stabilize the Computer Use startup-deadline test by asserting the cleanup contract directly
- document that iPhone and iPad distribution is TestFlight-only, with no IPA in GitHub releases

## Validation
- `npm test`
- `npm run type-check`
- `npm run lint`
- `node --test scripts/prepare-ci-release.test.mjs`
- `node --test scripts/run-macos-distribution.test.mjs`
- focused Computer Use startup-deadline test

Electron remains `0.31.0`; iOS and Android versions are unchanged.