### PR TITLE
fix(bots): unblock Custom create after catalog churn

### DIFF
--- a/main/handlers/bots.contract.test.ts
+++ b/main/handlers/bots.contract.test.ts
@@ -55,6 +55,10 @@ test("desktop Bot editor owns access and model selection through revisioned IPC"
   assert.match(bots, /updateBotAccess\(\{\s*audienceId: desktopAudienceId/u);
   assert.match(bots, /modelSelection\(\s*desktopAudienceId/u);
   assert.match(bots, /botAccessUpdateRendererError\(error\)/u);
+  assert.match(
+    bots,
+    /error instanceof BotCapabilityValidationError[\s\S]{0,80}return new Error\(error\.message\)/u,
+  );
   assert.doesNotMatch(bots, /bots:updateBotAccess[\s\S]{0,200}chatStore\./u);
 });
 

--- a/main/handlers/bots.ts
+++ b/main/handlers/bots.ts
@@ -500,7 +500,7 @@ function botAccessUpdateRendererError(error: unknown): unknown {
     return new Error("Some selected Bot access is unavailable. Refresh and review it.");
   }
   if (error instanceof BotCapabilityValidationError) {
-    return new Error("Bot capabilities changed. Refresh and review the current access choices.");
+    return new Error(error.message);
   }
   return error;
 }

--- a/main/services/bot-application-service.test.ts
+++ b/main/services/bot-application-service.test.ts
@@ -107,6 +107,7 @@ function fixture(options: {
   const events: string[] = [];
   const catalogTargets: Array<string | undefined> = [];
   const policyCatalogRevisions: string[] = [];
+  const bindCatalogRevisions: string[] = [];
   const catalogRetainedProviders: Array<readonly {
     sourceProviderId: string;
     sourceModelId: string;
@@ -444,6 +445,7 @@ function fixture(options: {
         binding?: { provider?: { sourceProviderId: string; sourceModelId: string } };
         modelBinding?: { sourceProviderId: string; sourceModelId: string };
       }) {
+        policyCatalogRevisions.push(input.access.catalogRevision);
         events.push(input.binding ? "policy:create:bound" : "policy:create");
         const value = botPolicy(input.botId);
         policies.set(input.botId, value);
@@ -581,8 +583,13 @@ function fixture(options: {
         catalogRetainedProviders.push(input?.retainedProviders);
         return catalog();
       },
-      async bindCustom(input?: { botId?: string; snapshot?: BotCapabilityCatalogSnapshot }) {
+      async bindCustom(input?: {
+        botId?: string;
+        snapshot?: BotCapabilityCatalogSnapshot;
+        catalogRevision?: string;
+      }) {
         if (!input?.snapshot) catalogTargets.push(input?.botId);
+        if (input?.catalogRevision !== undefined) bindCatalogRevisions.push(input.catalogRevision);
         events.push("catalog:bind-custom");
         return {
           version: 1,
@@ -675,6 +682,7 @@ function fixture(options: {
     catalogTargets,
     catalogRetainedProviders,
     policyCatalogRevisions,
+    bindCatalogRevisions,
     inventoryLeaseAcquisitions: () => inventoryLeaseAcquisitions,
   };
 }
@@ -1742,6 +1750,32 @@ test("Custom access is privately bound before it is committed", async () => {
   assert.ok(
     app.events.indexOf("catalog:bind-custom") < app.events.indexOf("policy:create:bound"),
   );
+});
+
+test("Bot creation re-bases a stale client catalog revision onto the current snapshot", async () => {
+  const app = fixture({
+    catalogRevisionPlan: ["catalog:churned"],
+  });
+  await app.service.initialize();
+  await app.service.createBot({
+    audienceId: "device:a",
+    bot: { name: "Planner", instructions: "Plan.", avatar: "spark" },
+    access: {
+      accessMode: "custom",
+      catalogRevision: CATALOG_REVISION,
+      custom: {
+        providerId: "provider:opaque",
+        modelId: "model:opaque",
+        fileScopeIds: ["scope:home"],
+        shellEnabled: false,
+        connectionIds: [],
+        skillIds: [],
+        otherCapabilityIds: [],
+      },
+    },
+  });
+  assert.equal(app.bindCatalogRevisions.at(-1), "catalog:churned");
+  assert.equal(app.policyCatalogRevisions.at(-1), "catalog:churned");
 });
 
 test("capability catalog retains a private binding but returns only the safe public projection", async () => {

--- a/main/services/bot-application-service.test.ts
+++ b/main/services/bot-application-service.test.ts
@@ -1774,8 +1774,14 @@ test("Bot creation re-bases a stale client catalog revision onto the current sna
       },
     },
   });
-  assert.equal(app.bindCatalogRevisions.at(-1), "catalog:churned");
-  assert.equal(app.policyCatalogRevisions.at(-1), "catalog:churned");
+  assert.equal(
+    app.bindCatalogRevisions[app.bindCatalogRevisions.length - 1],
+    "catalog:churned",
+  );
+  assert.equal(
+    app.policyCatalogRevisions[app.policyCatalogRevisions.length - 1],
+    "catalog:churned",
+  );
 });
 
 test("capability catalog retains a private binding but returns only the safe public projection", async () => {

--- a/main/services/bot-application-service.ts
+++ b/main/services/bot-application-service.ts
@@ -193,6 +193,15 @@ export class BotPersistentChatDeletionError extends Error {
   }
 }
 
+function withCurrentCatalogRevision<T extends { catalogRevision: string }>(
+  access: T,
+  catalogRevision: string,
+): T {
+  return access.catalogRevision === catalogRevision
+    ? access
+    : { ...access, catalogRevision };
+}
+
 function createReservation(operation: BotLifecycleOperation): BotManagedWorkspaceReservation {
   if (
     operation.kind !== "create_bot" ||
@@ -345,11 +354,16 @@ export function createBotApplicationService(deps: BotApplicationDependencies) {
     requested: BotAccessUpdate | undefined,
   ) => {
     const snapshot = await snapshotForAudience(audienceId);
-    let access: BotAccessUpdate = requested ?? {
-      accessMode: "full",
-      catalogRevision: snapshot.catalog.revision,
-      confirmedForeground: true,
-    };
+    // Audience-safe IDs are revalidated against this exact fresh snapshot.
+    // A stale wizard revision can therefore be rebased without accepting a
+    // removed or changed provider, model, connection, skill, or file scope.
+    let access: BotAccessUpdate = requested
+      ? withCurrentCatalogRevision(requested, snapshot.catalog.revision)
+      : {
+          accessMode: "full",
+          catalogRevision: snapshot.catalog.revision,
+          confirmedForeground: true,
+        };
     if (
       access.accessMode === "full" &&
       access.providerId === undefined &&
@@ -1191,10 +1205,10 @@ export function createBotApplicationService(deps: BotApplicationDependencies) {
           // Audience-safe IDs are revalidated against this exact fresh snapshot.
           // A stale client revision can therefore be rebased without accepting a
           // removed or changed provider, model, connection, skill, or file scope.
-          const access: BotAccessUpdate =
-            snapshot.catalog.revision === input.access.catalogRevision
-              ? input.access
-              : { ...input.access, catalogRevision: snapshot.catalog.revision };
+          const access: BotAccessUpdate = withCurrentCatalogRevision(
+            input.access,
+            snapshot.catalog.revision,
+          );
           const binding = access.accessMode === "custom"
             ? await deps.catalog.bindCustom({
                 audienceId: input.audienceId,
@@ -1531,10 +1545,10 @@ export function createBotApplicationService(deps: BotApplicationDependencies) {
             input.botId,
             retainedBotProviderForChat(chat),
           );
-          const access: BotChatAccessUpdate =
-            snapshot.catalog.revision === input.access.catalogRevision
-              ? input.access
-              : { ...input.access, catalogRevision: snapshot.catalog.revision };
+          const access: BotChatAccessUpdate = withCurrentCatalogRevision(
+            input.access,
+            snapshot.catalog.revision,
+          );
           assertCurrent();
           return deps.capabilityStore.updateChatPolicy({
             chatId: input.chatId,

--- a/main/services/bot-capability-bindings.test.ts
+++ b/main/services/bot-capability-bindings.test.ts
@@ -18,6 +18,7 @@ import {
   botCustomSelectionDrift,
   boundBotCustomSelectionFingerprint,
   createBotCapabilityOpaqueIdMint,
+  mintLegacyBotCapabilityOpaqueId,
   parseBoundBotCustomSelection,
   parseBoundBotProviderModel,
   reconcileBoundBotCustomSelection,
@@ -149,7 +150,7 @@ function binding(current = snapshot()): BoundBotCustomSelection {
   });
 }
 
-test("opaque ids are stable across restart keys and do not reveal source identity", () => {
+test("opaque ids stay stable across fingerprint churn and do not reveal source identity", () => {
   const first = createBotCapabilityOpaqueIdMint(key)("skill", "private-skill-id", digest("facts"));
   const restarted = createBotCapabilityOpaqueIdMint(Buffer.from(key))(
     "skill",
@@ -166,9 +167,22 @@ test("opaque ids are stable across restart keys and do not reveal source identit
     "private-skill-id",
     digest("changed-facts"),
   );
+  const otherSource = createBotCapabilityOpaqueIdMint(key)(
+    "skill",
+    "other-private-skill-id",
+    digest("facts"),
+  );
+  const legacy = mintLegacyBotCapabilityOpaqueId(
+    key,
+    "skill",
+    "private-skill-id",
+    digest("facts"),
+  );
   assert.equal(restarted, first);
   assert.notEqual(changedKey, first);
-  assert.notEqual(changedFacts, first);
+  assert.equal(changedFacts, first);
+  assert.notEqual(otherSource, first);
+  assert.notEqual(legacy, first);
   assert.equal(first.includes("private-skill-id"), false);
   assert.match(first, /^bc_skill_[A-Za-z0-9_-]+$/u);
   assert.throws(() => createBotCapabilityOpaqueIdMint(Buffer.alloc(31)), /32-byte key/u);
@@ -231,13 +245,14 @@ test("file choices enforce Full Mac exclusivity and approved-location Bot folder
   );
 });
 
-test("MCP schema/effect drift disables the old exact grant and creates an unavailable tombstone", () => {
+test("MCP schema/effect drift keeps the public id and fail-closes the stored grant", () => {
   const current = snapshot();
   const bound = binding(current);
   const changedInventory = inventory();
   changedInventory.connections[0]!.tools[0]!.inputSchemaFingerprint =
     digest("changed-input-schema");
   const changed = snapshot(changedInventory);
+  assert.equal(changed.catalog.connections[0]!.id, current.catalog.connections[0]!.id);
   const result = reconcileBoundBotCustomSelection(bound, changed);
   assert.equal(result.state, "drifted");
   assert.deepEqual(result.issues, [
@@ -247,35 +262,36 @@ test("MCP schema/effect drift disables the old exact grant and creates an unavai
       reason: "changed_or_removed",
     },
   ]);
-  const oldOption = result.catalogSnapshot.catalog.connections.find(
+  const option = result.catalogSnapshot.catalog.connections.find(
     ({ id }) => id === bound.selection.connectionIds[0],
   );
-  const newOption = result.catalogSnapshot.catalog.connections.find(
-    ({ id }) => id === changed.catalog.connections[0]!.id,
-  );
-  assert.equal(oldOption?.available, false);
-  assert.equal(newOption?.available, true);
+  assert.equal(option?.available, true);
   assert.doesNotThrow(() =>
-    validateSelectionAgainstCatalog(bound.selection, result.catalogSnapshot.catalog, {
-      requireAvailable: false,
+    bindBotCustomSelection({
+      selection: bound.selection,
+      catalogRevision: changed.catalog.revision,
+      snapshot: changed,
     }),
   );
-  assert.throws(() =>
+  assert.doesNotThrow(() =>
     validateSelectionAgainstCatalog(bound.selection, result.catalogSnapshot.catalog),
   );
+  assert.throws(() => assertBoundBotCustomSelectionCurrent(bound, changed), BotCapabilityBindingDriftError);
   const publicJson = JSON.stringify(result.catalogSnapshot.catalog);
   assert.equal(publicJson.includes("private-connection-id"), false);
   assert.equal(publicJson.includes("calendar_events"), false);
   assert.equal(publicJson.includes("Fingerprint"), false);
 });
 
-test("provider recipient and skill-content drift both mint new ids and retain safe old tombstones", () => {
+test("provider recipient and skill-content drift keep public ids and fail closed until re-bind", () => {
   const current = snapshot();
   const bound = binding(current);
   const changedInventory = inventory();
   changedInventory.providers[0]!.connectionFingerprint = digest("changed-recipient");
   changedInventory.skills[0]!.contentFingerprint = digest("changed-skill-content");
   const changed = snapshot(changedInventory);
+  assert.equal(changed.catalog.providers[0]!.id, current.catalog.providers[0]!.id);
+  assert.equal(changed.catalog.skills[0]!.id, current.catalog.skills[0]!.id);
   const reconciled = reconcileBoundBotCustomSelection(bound, changed);
   assert.equal(reconciled.state, "drifted");
   assert.deepEqual(
@@ -286,12 +302,19 @@ test("provider recipient and skill-content drift both mint new ids and retain sa
     reconciled.catalogSnapshot.catalog.providers.find(
       ({ id }) => id === bound.provider.providerOption.id,
     )?.available,
-    false,
+    true,
   );
   assert.equal(
     reconciled.catalogSnapshot.catalog.skills.find(({ id }) => id === bound.skills[0]!.option.id)
       ?.available,
-    false,
+    true,
+  );
+  assert.doesNotThrow(() =>
+    bindBotCustomSelection({
+      selection: bound.selection,
+      catalogRevision: changed.catalog.revision,
+      snapshot: changed,
+    }),
   );
   assert.throws(
     () => assertBoundBotCustomSelectionCurrent(bound, changed),
@@ -342,7 +365,7 @@ test("tampered bindings fail before tombstone projection or validation", () => {
   );
 });
 
-test("strict private binding reload preserves exact drift tombstones across restart", () => {
+test("strict private binding reload preserves identity-stable ids across fingerprint churn", () => {
   const beforeRestart = snapshot();
   const persistedJson = JSON.stringify(binding(beforeRestart));
   assert.equal(persistedJson.includes("/Users/"), false);
@@ -358,20 +381,65 @@ test("strict private binding reload preserves exact drift tombstones across rest
   const driftedInventory = inventory();
   driftedInventory.skills[0]!.contentFingerprint = digest("skill-content-after-restart");
   const afterDrift = snapshot(driftedInventory);
+  assert.equal(afterDrift.catalog.skills[0]!.id, afterRestart.selection.skillIds[0]);
   const reconciled = reconcileBoundBotCustomSelection(afterRestart, afterDrift);
   assert.equal(reconciled.state, "drifted");
   assert.equal(
     reconciled.catalogSnapshot.catalog.skills.find(
       ({ id }) => id === afterRestart.selection.skillIds[0],
     )?.available,
-    false,
-  );
-  assert.equal(
-    reconciled.catalogSnapshot.catalog.skills.find(
-      ({ id }) => id === afterDrift.catalog.skills[0]!.id,
-    )?.available,
     true,
   );
+  assert.throws(
+    () => assertBoundBotCustomSelectionCurrent(afterRestart, afterDrift),
+    BotCapabilityBindingDriftError,
+  );
+  assert.doesNotThrow(() =>
+    bindBotCustomSelection({
+      selection: afterRestart.selection,
+      catalogRevision: afterDrift.catalog.revision,
+      snapshot: afterDrift,
+    }),
+  );
+});
+
+test("legacy v1 opaque ids still verify after identity-stable minting", () => {
+  const current = snapshot();
+  const bound = binding(current);
+  const skill = bound.skills[0]!;
+  const legacySkillId = mintLegacyBotCapabilityOpaqueId(
+    key,
+    "skill",
+    skill.sourceId,
+    skill.exactFingerprint,
+  );
+  const stored = structuredClone(bound);
+  stored.skills[0] = { ...skill, option: { ...skill.option, id: legacySkillId } };
+  stored.selection = { ...bound.selection, skillIds: [legacySkillId] };
+  const parsed = parseBoundBotCustomSelection(stored);
+  assert.doesNotThrow(() =>
+    assertBoundBotCustomSelectionOpaqueIds(parsed, createBotCapabilityOpaqueIdMint(key)),
+  );
+});
+
+test("removed sources keep unavailable tombstones with the stored public id", () => {
+  const current = snapshot();
+  const bound = binding(current);
+  const removedInventory = inventory();
+  removedInventory.skills = [];
+  const withoutSkill = snapshot(removedInventory);
+  const withTombstones = withBotCapabilityTombstones(withoutSkill, [bound]);
+  const option = withTombstones.catalog.skills.find(
+    ({ id }) => id === bound.selection.skillIds[0],
+  );
+  assert.equal(option?.available, false);
+  assert.deepEqual(botCustomSelectionDrift(bound, withoutSkill), [
+    {
+      group: "skill",
+      selectionId: bound.selection.skillIds[0],
+      reason: "changed_or_removed",
+    },
+  ]);
 });
 
 test("legacy provider bindings without image metadata do not drift after capability discovery", () => {
@@ -537,6 +605,16 @@ test("main catalog service uses injected inventories, stable persisted key, and 
   });
   assert.equal(reconciled.state, "drifted");
   assert.equal(reconciled.issues[0]?.group, "connection");
+  assert.equal(reconciled.selection.connectionIds[0], bound.selection.connectionIds[0]);
+  const refreshed = await service.snapshot({ audienceId: "device_a" });
+  assert.equal(refreshed.catalog.connections[0]!.id, first.catalog.connections[0]!.id);
+  await assert.doesNotReject(
+    service.bindCustom({
+      audienceId: "device_a",
+      selection: bound.selection,
+      catalogRevision: refreshed.catalog.revision,
+    }),
+  );
 });
 
 test("main catalog service honors cancellation without app globals", async () => {

--- a/main/services/bot-capability-bindings.ts
+++ b/main/services/bot-capability-bindings.ts
@@ -2,7 +2,9 @@ import { createHmac } from "node:crypto";
 import { types as utilTypes } from "node:util";
 import {
   BOT_CAPABILITY_LIMITS,
+  BOT_FILE_SCOPE_SELECTION_GUIDANCE,
   BotCapabilityValidationError,
+  botFileScopeSelectionIsCoherent,
   cloneBotCustomSelection,
   isBoundedBotText,
   isPathSafeBotCapabilityId,
@@ -35,6 +37,9 @@ export const BOT_CAPABILITY_OPAQUE_KEY_BYTES = 32;
 export const BOT_CAPABILITY_BINDING_VERSION = 1 as const;
 
 const EXACT_SHA256 = /^[a-f0-9]{64}$/u;
+const OPAQUE_ID_DOMAIN_V1 = "aiden-bot-capability-v1";
+const OPAQUE_ID_DOMAIN_V2 = "aiden-bot-capability-v2";
+const mintKeys = new WeakMap<BotCapabilityOpaqueIdMint, Buffer>();
 
 export interface BoundBotProviderModel {
   providerOption: Omit<BotProviderOption, "models">;
@@ -136,36 +141,83 @@ function copyBytes(value: Uint8Array): Buffer {
   return Buffer.from(value);
 }
 
+function mintOpaqueIdWithDomain(
+  key: Buffer,
+  domain: typeof OPAQUE_ID_DOMAIN_V1 | typeof OPAQUE_ID_DOMAIN_V2,
+  namespace: BotCapabilityOpaqueNamespace,
+  sourceIdentity: string,
+  exactFingerprint: string,
+): string {
+  if (!EXACT_SHA256.test(exactFingerprint) || !sourceIdentity) {
+    throw new Error("Cannot mint a Bot capability id from invalid exact facts.");
+  }
+  const hmac = createHmac("sha256", key)
+    .update(domain)
+    .update("\0")
+    .update(namespace)
+    .update("\0")
+    .update(sourceIdentity);
+  // v1 mixed live fingerprints into the public id, so MCP/skill churn rotated
+  // checkboxes mid-wizard. v2 is identity-stable; exact facts stay in bindings.
+  if (domain === OPAQUE_ID_DOMAIN_V1) {
+    hmac.update("\0").update(exactFingerprint);
+  }
+  const id = `bc_${namespace}_${hmac.digest("base64url")}`;
+  if (!isPathSafeBotCapabilityId(id)) {
+    throw new Error("Minted Bot capability id exceeded the public identity contract.");
+  }
+  return id;
+}
+
 /**
  * Create stable, unlinkable selection ids. Callers must load the same private
  * key after every restart; this helper deliberately never generates one.
+ * Public ids follow source identity, not live fingerprints, so a wizard can
+ * keep the same checkboxes while Custom still fail-closes on stored facts.
  */
 export function createBotCapabilityOpaqueIdMint(
   persistedKey: Uint8Array,
 ): BotCapabilityOpaqueIdMint {
   const key = copyBytes(persistedKey);
-  return (
+  const mint: BotCapabilityOpaqueIdMint = (
     namespace: BotCapabilityOpaqueNamespace,
     sourceIdentity: string,
     exactFingerprint: string,
-  ): string => {
-    if (!EXACT_SHA256.test(exactFingerprint) || !sourceIdentity) {
-      throw new Error("Cannot mint a Bot capability id from invalid exact facts.");
-    }
-    const digest = createHmac("sha256", key)
-      .update("aiden-bot-capability-v1\0")
-      .update(namespace)
-      .update("\0")
-      .update(sourceIdentity)
-      .update("\0")
-      .update(exactFingerprint)
-      .digest("base64url");
-    const id = `bc_${namespace}_${digest}`;
-    if (!isPathSafeBotCapabilityId(id)) {
-      throw new Error("Minted Bot capability id exceeded the public identity contract.");
-    }
-    return id;
-  };
+  ): string =>
+    mintOpaqueIdWithDomain(key, OPAQUE_ID_DOMAIN_V2, namespace, sourceIdentity, exactFingerprint);
+  mintKeys.set(mint, key);
+  return mint;
+}
+
+export function mintLegacyBotCapabilityOpaqueId(
+  persistedKey: Uint8Array,
+  namespace: BotCapabilityOpaqueNamespace,
+  sourceIdentity: string,
+  exactFingerprint: string,
+): string {
+  return mintOpaqueIdWithDomain(
+    copyBytes(persistedKey),
+    OPAQUE_ID_DOMAIN_V1,
+    namespace,
+    sourceIdentity,
+    exactFingerprint,
+  );
+}
+
+function opaqueIdMatchesMint(
+  mintOpaqueId: BotCapabilityOpaqueIdMint,
+  namespace: BotCapabilityOpaqueNamespace,
+  sourceIdentity: string,
+  exactFingerprint: string,
+  actualId: string,
+): boolean {
+  if (actualId === mintOpaqueId(namespace, sourceIdentity, exactFingerprint)) return true;
+  const key = mintKeys.get(mintOpaqueId);
+  return (
+    key !== undefined &&
+    actualId ===
+      mintOpaqueIdWithDomain(key, OPAQUE_ID_DOMAIN_V1, namespace, sourceIdentity, exactFingerprint)
+  );
 }
 
 function compareText(left: string, right: string): number {
@@ -859,34 +911,50 @@ export function assertBoundBotCustomSelectionOpaqueIds(
   mintOpaqueId: BotCapabilityOpaqueIdMint,
 ): void {
   const binding = parseBoundBotCustomSelection(value);
-  const expectedProviderId = mintOpaqueId(
-    "provider",
-    binding.provider.sourceProviderId,
-    binding.provider.providerExactFingerprint,
-  );
-  const expectedModelId = mintOpaqueId(
-    "model",
-    `${binding.provider.sourceProviderId}\0${binding.provider.sourceModelId}`,
-    binding.provider.modelExactFingerprint,
-  );
   const idsMatch =
-    binding.provider.providerOption.id === expectedProviderId &&
-    binding.provider.modelOption.id === expectedModelId &&
-    binding.fileScopes.every(
-      (scope) => scope.option.id === mintOpaqueId("file", scope.sourceId, scope.exactFingerprint),
+    opaqueIdMatchesMint(
+      mintOpaqueId,
+      "provider",
+      binding.provider.sourceProviderId,
+      binding.provider.providerExactFingerprint,
+      binding.provider.providerOption.id,
     ) &&
-    binding.connections.every(
-      (connection) =>
-        connection.option.id ===
-        mintOpaqueId("connection", connection.sourceId, connection.exactFingerprint),
+    opaqueIdMatchesMint(
+      mintOpaqueId,
+      "model",
+      `${binding.provider.sourceProviderId}\0${binding.provider.sourceModelId}`,
+      binding.provider.modelExactFingerprint,
+      binding.provider.modelOption.id,
     ) &&
-    binding.skills.every(
-      (skill) => skill.option.id === mintOpaqueId("skill", skill.sourceId, skill.exactFingerprint),
+    binding.fileScopes.every((scope) =>
+      opaqueIdMatchesMint(mintOpaqueId, "file", scope.sourceId, scope.exactFingerprint, scope.option.id),
     ) &&
-    binding.otherCapabilities.every(
-      (capability) =>
-        capability.option.id ===
-        mintOpaqueId("other", capability.kind, capability.exactFingerprint),
+    binding.connections.every((connection) =>
+      opaqueIdMatchesMint(
+        mintOpaqueId,
+        "connection",
+        connection.sourceId,
+        connection.exactFingerprint,
+        connection.option.id,
+      ),
+    ) &&
+    binding.skills.every((skill) =>
+      opaqueIdMatchesMint(
+        mintOpaqueId,
+        "skill",
+        skill.sourceId,
+        skill.exactFingerprint,
+        skill.option.id,
+      ),
+    ) &&
+    binding.otherCapabilities.every((capability) =>
+      opaqueIdMatchesMint(
+        mintOpaqueId,
+        "other",
+        capability.kind,
+        capability.exactFingerprint,
+        capability.option.id,
+      ),
     );
   if (!idsMatch) {
     throw new Error("Bot Custom binding opaque ids do not match their persisted exact facts.");
@@ -935,17 +1003,10 @@ function fileSelectionIsCoherent(
   selection: BotCustomSelection,
   snapshot: BotCapabilityCatalogSnapshot,
 ): boolean {
-  const scopes = selection.fileScopeIds.map((id) =>
-    snapshot.resources.fileScopes.find(({ option }) => option.id === id),
+  return botFileScopeSelectionIsCoherent(
+    selection.fileScopeIds,
+    snapshot.resources.fileScopes.map(({ option }) => option),
   );
-  if (scopes.some((scope) => !scope)) return false;
-  const kinds = scopes.map((scope) => scope!.option.kind);
-  const fullMac = kinds.filter((kind) => kind === "full_mac").length;
-  const botHome = kinds.filter((kind) => kind === "bot_home").length;
-  const approved = kinds.filter((kind) => kind === "approved_location").length;
-  if (fullMac > 0) return fullMac === 1 && kinds.length === 1;
-  if (approved > 0) return botHome === 1;
-  return botHome <= 1;
 }
 
 function bindProvider(
@@ -1019,9 +1080,7 @@ export function bindBotCustomSelection(input: {
   const selection = parseBotCustomSelection(input.selection);
   validateSelectionAgainstCatalog(selection, input.snapshot.catalog);
   if (!fileSelectionIsCoherent(selection, input.snapshot)) {
-    throw new BotCapabilityValidationError(
-      "Choose Full Mac, Bot folder, approved locations with the Bot folder, or Files Off.",
-    );
+    throw new BotCapabilityValidationError(BOT_FILE_SCOPE_SELECTION_GUIDANCE);
   }
   const byOptionId = <T extends { option: { id: string; available: boolean } }>(
     choices: readonly T[],
@@ -1146,6 +1205,44 @@ function resourceIssue(
   return current.option.available ? undefined : issue(group, selectionId, "unavailable");
 }
 
+function findByIdOrSource<T extends { option: { id: string }; sourceId: string }>(
+  items: readonly T[],
+  selectionId: string,
+  sourceId: string,
+): T | undefined {
+  return (
+    items.find((item) => item.option.id === selectionId) ??
+    items.find((item) => item.sourceId === sourceId)
+  );
+}
+
+function adoptRetainedPublicId<T extends { option: { id: string } }>(
+  existing: T,
+  retainedId: string,
+): T {
+  if (existing.option.id !== retainedId) {
+    existing.option.id = retainedId;
+  }
+  return existing;
+}
+
+function findOrAdoptByIdentity<T extends { option: { id: string } }>(
+  collection: T[],
+  retainedId: string,
+  matchIdentity: (item: T) => boolean,
+  label: string,
+): T | undefined {
+  const byId = collection.find((item) => item.option.id === retainedId);
+  if (byId) {
+    if (!matchIdentity(byId)) {
+      throw new Error(`Bot ${label} opaque id collision detected.`);
+    }
+    return byId;
+  }
+  const byIdentity = collection.find(matchIdentity);
+  return byIdentity ? adoptRetainedPublicId(byIdentity, retainedId) : undefined;
+}
+
 /** Return only public opaque drift facts; private identities never enter error text. */
 export function botCustomSelectionDrift(
   binding: BoundBotCustomSelection,
@@ -1153,8 +1250,10 @@ export function botCustomSelectionDrift(
 ): BotCapabilityDriftIssue[] {
   binding = parseBoundBotCustomSelection(binding);
   const issues: BotCapabilityDriftIssue[] = [];
-  const provider = current.resources.providers.find(
-    ({ option }) => option.id === binding.provider.providerOption.id,
+  const provider = findByIdOrSource(
+    current.resources.providers,
+    binding.provider.providerOption.id,
+    binding.provider.sourceProviderId,
   );
   if (
     !provider ||
@@ -1165,9 +1264,13 @@ export function botCustomSelectionDrift(
   } else if (!provider.option.available) {
     issues.push(issue("provider", binding.provider.providerOption.id, "unavailable"));
   }
-  const model = provider?.models.find(
-    ({ option }) => option.id === binding.provider.modelOption.id,
-  );
+  const model = provider
+    ? findByIdOrSource(
+        provider.models,
+        binding.provider.modelOption.id,
+        binding.provider.sourceModelId,
+      )
+    : undefined;
   if (
     !model ||
     model.sourceId !== binding.provider.sourceModelId ||
@@ -1186,21 +1289,25 @@ export function botCustomSelectionDrift(
     }
   }
   for (const bound of binding.fileScopes) {
-    const found = current.resources.fileScopes.find(({ option }) => option.id === bound.option.id);
+    const found = findByIdOrSource(current.resources.fileScopes, bound.option.id, bound.sourceId);
     const foundIssue = found?.sourceId !== bound.sourceId
       ? issue("file_scope", bound.option.id, "changed_or_removed")
       : resourceIssue("file_scope", bound.option.id, bound.exactFingerprint, found);
     if (foundIssue) issues.push(foundIssue);
   }
   for (const bound of binding.connections) {
-    const found = current.resources.connections.find(({ option }) => option.id === bound.option.id);
+    const found = findByIdOrSource(
+      current.resources.connections,
+      bound.option.id,
+      bound.sourceId,
+    );
     const foundIssue = found?.sourceId !== bound.sourceId
       ? issue("connection", bound.option.id, "changed_or_removed")
       : resourceIssue("connection", bound.option.id, bound.exactFingerprint, found);
     if (foundIssue) issues.push(foundIssue);
   }
   for (const bound of binding.skills) {
-    const found = current.resources.skills.find(({ option }) => option.id === bound.option.id);
+    const found = findByIdOrSource(current.resources.skills, bound.option.id, bound.sourceId);
     const foundIssue = found?.sourceId !== bound.sourceId
       ? issue("skill", bound.option.id, "changed_or_removed")
       : resourceIssue("skill", bound.option.id, bound.exactFingerprint, found);
@@ -1208,7 +1315,8 @@ export function botCustomSelectionDrift(
   }
   for (const bound of binding.otherCapabilities) {
     const found = current.resources.otherCapabilities.find(
-      ({ option }) => option.id === bound.option.id,
+      (capability) =>
+        capability.option.id === bound.option.id || capability.kind === bound.kind,
     );
     const foundIssue = resourceIssue(
       "other_capability",
@@ -1237,19 +1345,11 @@ function unavailableOption<T extends BotCapabilityOption>(option: T): T {
   return { ...option, available: false };
 }
 
-function sameOrCollision(
-  current: { exactFingerprint: string },
-  retained: { exactFingerprint: string },
-  label: string,
-): void {
-  if (current.exactFingerprint !== retained.exactFingerprint) {
-    throw new Error(`Bot ${label} opaque id collision detected.`);
-  }
-}
-
 /**
- * Add unavailable public tombstones for exact grants that disappeared or
- * changed. New resources retain their new opaque ids, so Custom never widens.
+ * Keep stored public ids visible when a source is gone. Same-identity fingerprint
+ * drift keeps the live row available so the user can re-bind; Custom still
+ * fail-closes at admit until they save. Distinct sources that hash to one id
+ * remain a collision.
  */
 export function withBotCapabilityTombstones(
   current: BotCapabilityCatalogSnapshot,
@@ -1265,16 +1365,13 @@ export function withBotCapabilityTombstones(
   };
   for (const candidate of retainedBindings) {
     const binding = parseBoundBotCustomSelection(candidate);
-    let provider = resources.providers.find(
-      ({ option }) => option.id === binding.provider.providerOption.id,
+    let provider = findOrAdoptByIdentity(
+      resources.providers,
+      binding.provider.providerOption.id,
+      (candidate) => candidate.sourceId === binding.provider.sourceProviderId,
+      "provider",
     );
-    if (provider) {
-      sameOrCollision(
-        provider,
-        { exactFingerprint: binding.provider.providerExactFingerprint },
-        "provider",
-      );
-    } else {
+    if (!provider) {
       provider = {
         sourceId: binding.provider.sourceProviderId,
         connectionFingerprint: binding.provider.connectionFingerprint,
@@ -1288,12 +1385,13 @@ export function withBotCapabilityTombstones(
       };
       resources.providers.push(provider);
     }
-    const model = provider.models.find(
-      ({ option }) => option.id === binding.provider.modelOption.id,
+    const model = findOrAdoptByIdentity(
+      provider.models,
+      binding.provider.modelOption.id,
+      (candidate) => candidate.sourceId === binding.provider.sourceModelId,
+      "model",
     );
-    if (model) {
-      sameOrCollision(model, { exactFingerprint: binding.provider.modelExactFingerprint }, "model");
-    } else {
+    if (!model) {
       provider.models.push({
         sourceId: binding.provider.sourceModelId,
         modelFingerprint: binding.provider.modelFingerprint,
@@ -1304,16 +1402,14 @@ export function withBotCapabilityTombstones(
     provider.models.sort((left, right) => compareText(left.option.id, right.option.id));
     provider.option.models = provider.models.map(({ option }) => ({ ...option }));
 
-    const appendResource = <T extends { option: BotCapabilityOption; exactFingerprint: string }>(
+    const appendResource = <T extends { option: BotCapabilityOption }>(
       collection: T[],
       retained: T,
       label: string,
+      matchIdentity: (item: T) => boolean,
     ) => {
-      const existing = collection.find(({ option }) => option.id === retained.option.id);
-      if (existing) {
-        sameOrCollision(existing, retained, label);
-        return;
-      }
+      const existing = findOrAdoptByIdentity(collection, retained.option.id, matchIdentity, label);
+      if (existing) return;
       collection.push({ ...retained, option: unavailableOption(retained.option) });
     };
     for (const scope of binding.fileScopes) {
@@ -1326,6 +1422,7 @@ export function withBotCapabilityTombstones(
           exactFingerprint: scope.exactFingerprint,
         },
         "file-scope",
+        (item) => item.sourceId === scope.sourceId,
       );
     }
     for (const connection of binding.connections) {
@@ -1337,16 +1434,23 @@ export function withBotCapabilityTombstones(
           tools: connection.tools.map((tool) => ({ ...tool })),
         },
         "connection",
+        (item) => item.sourceId === connection.sourceId,
       );
     }
     for (const skill of binding.skills) {
-      appendResource(resources.skills, { ...skill, option: { ...skill.option } }, "skill");
+      appendResource(
+        resources.skills,
+        { ...skill, option: { ...skill.option } },
+        "skill",
+        (item) => item.sourceId === skill.sourceId,
+      );
     }
     for (const capability of binding.otherCapabilities) {
       appendResource(
         resources.otherCapabilities,
         { ...capability, option: { ...capability.option } },
         "ordinary-capability",
+        (item) => item.kind === capability.kind,
       );
     }
   }

--- a/main/services/bot-capability-catalog-core.test.ts
+++ b/main/services/bot-capability-catalog-core.test.ts
@@ -183,7 +183,7 @@ test("catalog revision and opaque ids are deterministic independent of inventory
   assert.notDeepEqual(accepted.catalog.notice, first.catalog.notice);
 });
 
-test("MCP opaque binding changes on connection, tool schema, or effect drift", () => {
+test("MCP public ids stay identity-stable while private fingerprints still drift", () => {
   const baseline = snapshot();
   const baselineConnection = baseline.resources.connections[0]!;
   assert.equal(baselineConnection.tools.length, 2);
@@ -210,9 +210,11 @@ test("MCP opaque binding changes on connection, tool schema, or effect drift", (
   for (const mutate of mutations) {
     const changed = inventory();
     mutate(changed);
+    const drifted = snapshot(changed);
+    assert.equal(drifted.catalog.connections[0]!.id, baseline.catalog.connections[0]!.id);
     assert.notEqual(
-      snapshot(changed).catalog.connections[0]!.id,
-      baseline.catalog.connections[0]!.id,
+      drifted.resources.connections[0]!.exactFingerprint,
+      baselineConnection.exactFingerprint,
     );
   }
 });
@@ -222,7 +224,11 @@ test("skill grants bind identity and content without projecting content or paths
   const changed = inventory();
   changed.skills[0]!.contentFingerprint = digest("changed-private-skill-content");
   const drifted = snapshot(changed);
-  assert.notEqual(drifted.catalog.skills[0]!.id, baseline.catalog.skills[0]!.id);
+  assert.equal(drifted.catalog.skills[0]!.id, baseline.catalog.skills[0]!.id);
+  assert.notEqual(
+    drifted.resources.skills[0]!.exactFingerprint,
+    baseline.resources.skills[0]!.exactFingerprint,
+  );
   assert.equal(JSON.stringify(drifted.catalog).includes("changed-private-skill-content"), false);
 
   const withPath = inventory() as unknown as {

--- a/main/services/bot-capability-catalog-core.ts
+++ b/main/services/bot-capability-catalog-core.ts
@@ -206,6 +206,7 @@ export type BotCapabilityOpaqueNamespace =
   | "skill"
   | "other";
 
+/** Mint a public selection id. Exact fingerprints are required and stored privately; current minting follows source identity so live fact churn does not rotate checkboxes. */
 export type BotCapabilityOpaqueIdMint = (
   namespace: BotCapabilityOpaqueNamespace,
   sourceIdentity: string,

--- a/main/services/bot-capability-production-shape.test.ts
+++ b/main/services/bot-capability-production-shape.test.ts
@@ -66,7 +66,7 @@ test("Bot provider signatures bind stored and custom authority while rejecting a
   assert.doesNotMatch(JSON.stringify(signatures), /stored-secret|oauth-a|custom-secret/u);
 });
 
-test("production-shaped catalogs keep restart identity and rotate exact opaque grants", async (t) => {
+test("production-shaped catalogs keep restart identity and public ids across exact-grant rotation", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "aiden-bot-production-catalog-"));
   t.after(() => fs.rm(root, { recursive: true, force: true }));
   let credential = hash("credential-a");
@@ -117,7 +117,11 @@ test("production-shaped catalogs keep restart identity and rotate exact opaque g
 
   credential = hash("credential-b");
   const rotated = await (await createService()).snapshot({ audienceId: "device_a" });
-  assert.notEqual(rotated.catalog.providers[0]?.id, first.catalog.providers[0]?.id);
+  assert.equal(rotated.catalog.providers[0]?.id, first.catalog.providers[0]?.id);
+  assert.notEqual(
+    rotated.resources.providers[0]?.connectionFingerprint,
+    first.resources.providers[0]?.connectionFingerprint,
+  );
 
   skills = [];
   await (await createService()).snapshot({ audienceId: "device_a" });
@@ -129,7 +133,7 @@ test("production-shaped catalogs keep restart identity and rotate exact opaque g
     available: true,
   }];
   const readded = await (await createService()).snapshot({ audienceId: "device_a" });
-  assert.notEqual(readded.catalog.skills[0]?.id, first.catalog.skills[0]?.id);
+  assert.equal(readded.catalog.skills[0]?.id, first.catalog.skills[0]?.id);
 });
 
 test("Bot-targeted catalogs isolate managed-home skills and stay stable across restart", async (t) => {

--- a/renderer/main/bots-view.test.tsx
+++ b/renderer/main/bots-view.test.tsx
@@ -50,6 +50,7 @@ test("bot detail owns one-to-one Telegram bind and unbind controls", () => {
 
 test("bots UI edits definitions and creates conversations through dedicated IPC", () => {
   const view = source("./bots-view.tsx");
+  assert.match(view, /botsApi\.getCapabilityCatalog\(\)[\s\S]*botsApi\.create\(/u);
   assert.match(view, /botsApi\.create\(\{\s*bot: createInputFromDraft\(draft\),\s*access:/u);
   assert.match(
     view,
@@ -94,6 +95,9 @@ test("bot editor owns access mode, model selection, and capability toggles", () 
   assert.match(view, /The attached image and a focused question go to this provider/u);
   assert.match(view, /No image-capable model is connected/u);
   assert.match(view, /Settings → Providers/u);
+  assert.match(view, /nextBotFileScopeIds\(/u);
+  assert.match(view, /botFileScopeSelectionIsCoherent\(/u);
+  assert.match(view, /BOT_FILE_SCOPE_SELECTION_GUIDANCE/u);
   // Capability toggles with Full-mode disabling, matching the iOS sections.
   assert.match(view, /aria-label=\{`Allow \$\{option\.label\} for this bot`\}/u);
   assert.match(view, /aria-label="Allow run commands for this bot"/u);

--- a/renderer/main/bots-view.tsx
+++ b/renderer/main/bots-view.tsx
@@ -59,7 +59,10 @@ import {
 } from "../shared/bot-editor-save";
 import {
   BOT_ACCESS_SUMMARIES,
+  BOT_FILE_SCOPE_SELECTION_GUIDANCE,
   BOT_FULL_ACCESS_NOTICE_VERSION,
+  botFileScopeSelectionIsCoherent,
+  nextBotFileScopeIds,
   type BotAccessUpdate,
   type BotCapabilityCatalog,
   type BotCapabilityOption,
@@ -210,6 +213,9 @@ function buildBotAccessUpdate(
   if (draft.shellEnabled && !catalog.shellAvailable) {
     throw new Error("Run commands is not currently available on this Mac.");
   }
+  if (!botFileScopeSelectionIsCoherent(draft.fileScopeIds, catalog.fileScopes)) {
+    throw new Error(BOT_FILE_SCOPE_SELECTION_GUIDANCE);
+  }
   return {
     accessMode: "custom",
     catalogRevision: catalog.revision,
@@ -344,9 +350,12 @@ function BotEditor({
       if (!committedBot) {
         // Creation is one main-owned transaction: identity, workspace, model,
         // and access either become visible together or are rolled back together.
+        // Re-read the catalog so Custom grants bind against current opaque ids.
+        const latestCatalog = await botsApi.getCapabilityCatalog();
+        qc.setQueryData(queryKeys.botCapabilityCatalog, latestCatalog);
         saved = await botsApi.create({
           bot: createInputFromDraft(draft),
-          access: buildBotAccessUpdate(accessDraft, catalog),
+          access: buildBotAccessUpdate(accessDraft, latestCatalog),
         });
         setCommittedBot(saved);
         setIdentityBaseline(draftFromBot(saved));
@@ -433,7 +442,13 @@ function BotEditor({
     checked: boolean,
   ) =>
     setAccessDraft((current) => {
-      if (!current) return current;
+      if (!current || !catalog) return current;
+      if (key === "fileScopeIds") {
+        return {
+          ...current,
+          fileScopeIds: nextBotFileScopeIds(current.fileScopeIds, catalog.fileScopes, id, checked),
+        };
+      }
       const ids = new Set(current[key]);
       if (checked) ids.add(id);
       else ids.delete(id);

--- a/renderer/shared/bot-capabilities.test.ts
+++ b/renderer/shared/bot-capabilities.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   botCustomSelectionIsSubset,
+  BOT_FILE_SCOPE_SELECTION_GUIDANCE,
+  botFileScopeSelectionIsCoherent,
   intersectBotCustomSelections,
+  nextBotFileScopeIds,
   parseBotAccessUpdate,
   type BotCustomSelection,
   type BotFileScopeOption,
@@ -78,6 +81,20 @@ test("Full Bot access accepts only an exact optional provider/model pair", () =>
     confirmedForeground: true,
     visionModel: { providerId: "provider:vision" },
   }), /foreground confirmation/u);
+});
+
+test("Custom file-scope toggles stay binder-coherent", () => {
+  assert.equal(botFileScopeSelectionIsCoherent(["full", "home"], scopes), false);
+  assert.equal(botFileScopeSelectionIsCoherent(["home", "documents"], scopes), true);
+  assert.equal(botFileScopeSelectionIsCoherent(["documents"], scopes), false);
+  assert.equal(botFileScopeSelectionIsCoherent(["full"], scopes), true);
+  assert.deepEqual(nextBotFileScopeIds(["home"], scopes, "full", true), ["full"]);
+  assert.deepEqual(
+    nextBotFileScopeIds(["full"], scopes, "documents", true).sort(),
+    ["documents", "home"].sort(),
+  );
+  assert.deepEqual(nextBotFileScopeIds(["home", "documents"], scopes, "home", false), []);
+  assert.equal(BOT_FILE_SCOPE_SELECTION_GUIDANCE.includes("Full Mac"), true);
 });
 
 test("file-scope intersection preserves a chat reduction below Full Mac", () => {

--- a/renderer/shared/bot-capabilities.ts
+++ b/renderer/shared/bot-capabilities.ts
@@ -463,6 +463,55 @@ export function cloneBotCustomSelection(selection: BotCustomSelection): BotCusto
   };
 }
 
+export const BOT_FILE_SCOPE_SELECTION_GUIDANCE =
+  "Choose Full Mac, Bot folder, approved locations with the Bot folder, or Files Off.";
+
+/** True when Custom file scopes match the grant rules the binder will enforce. */
+export function botFileScopeSelectionIsCoherent(
+  fileScopeIds: readonly string[],
+  fileScopes: readonly Pick<BotFileScopeOption, "id" | "kind">[],
+): boolean {
+  const scopes = fileScopeIds.map((id) => fileScopes.find((scope) => scope.id === id));
+  if (scopes.some((scope) => !scope)) return false;
+  const kinds = scopes.map((scope) => scope!.kind);
+  const fullMac = kinds.filter((kind) => kind === "full_mac").length;
+  const botHome = kinds.filter((kind) => kind === "bot_home").length;
+  const approved = kinds.filter((kind) => kind === "approved_location").length;
+  if (fullMac > 0) return fullMac === 1 && kinds.length === 1;
+  if (approved > 0) return botHome === 1;
+  return botHome <= 1;
+}
+
+/** Apply one file-scope toggle while preserving binder-coherent grants. */
+export function nextBotFileScopeIds(
+  fileScopeIds: readonly string[],
+  fileScopes: readonly Pick<BotFileScopeOption, "id" | "kind">[],
+  id: string,
+  enabled: boolean,
+): string[] {
+  const option = fileScopes.find((scope) => scope.id === id);
+  if (!option) return [...fileScopeIds];
+  const selected = new Set(fileScopeIds);
+  const removeKind = (kind: BotFileScopeOption["kind"]) => {
+    for (const scope of fileScopes) {
+      if (scope.kind === kind) selected.delete(scope.id);
+    }
+  };
+  if (!enabled) {
+    selected.delete(id);
+    if (option.kind === "bot_home") removeKind("approved_location");
+    return [...selected];
+  }
+  if (option.kind === "full_mac") return [id];
+  removeKind("full_mac");
+  selected.add(id);
+  if (option.kind === "approved_location") {
+    const botHome = fileScopes.find((scope) => scope.kind === "bot_home");
+    if (botHome) selected.add(botHome.id);
+  }
+  return [...selected];
+}
+
 export function botCustomSelectionIsSubset(
   candidate: BotCustomSelection,
   ceiling: BotCustomSelection,


### PR DESCRIPTION
## Summary
- Keep Custom file-scope toggles mutually coherent, rebase create onto the live catalog revision, and pass binder validation messages through to the desktop editor so create no longer fails as a generic stale-capability toast.
- Mint public capability ids from source identity instead of live MCP/skill fingerprints, while still fail-closing stored Custom grants until the user re-binds. Existing v1 ids continue to verify.
- Create-rebase tests index the last catalog revision without `Array.at`, so CI typecheck matches the repo `lib` target.

## Test plan
- [ ] `npm run test:bots`
- [ ] Custom create with a lingering wizard catalog: Full Mac vs Bot folder toggles stay exclusive; create succeeds after catalog churn
- [ ] Existing Custom bots still fail closed on skill/MCP fingerprint drift until access is saved again; removed skills stay unavailable tombstones
- [ ] Rebuild/reinstall before expecting `/Applications/Aiden Agent.app` to pick this up