### PR TITLE
Improve response formatting and transcript typography

### DIFF
--- a/main/services/assistant/system-prompt.test.ts
+++ b/main/services/assistant/system-prompt.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildAssistantSystemPrompt, withTelegramAgentContract } from "./system-prompt.js";
+import {
+  PI_CHAT_SYSTEM_PROMPT,
+  RESPONSE_FORMAT_GUIDANCE,
+} from "../response-format-guidance.js";
 
 const base = {
   settingsSections: ["providers", "appearance"],
@@ -16,6 +20,18 @@ test("introduces Aiden as an app assistant without granting dock coding access",
   assert.match(prompt, /Aiden Agent/u);
   assert.match(prompt, /cannot read or change project files/u);
   assert.match(prompt, /future scheduled project or MCP automation/u);
+});
+
+test("shares restrained response-structure guidance across conversational surfaces", () => {
+  const prompt = buildAssistantSystemPrompt(base);
+  assert.match(prompt, /Use short paragraphs/u);
+  assert.match(prompt, /bullets for genuinely parallel items/u);
+  assert.match(prompt, /numbered lists only when order matters/u);
+  assert.match(prompt, /headings only when a longer response benefits/u);
+  assert.match(prompt, /do not turn every response into a checklist/u);
+  assert.ok(prompt.includes(RESPONSE_FORMAT_GUIDANCE));
+  assert.ok(PI_CHAT_SYSTEM_PROMPT.includes(RESPONSE_FORMAT_GUIDANCE));
+  assert.match(PI_CHAT_SYSTEM_PROMPT, /using Markdown for formatting/u);
 });
 
 test("grounds the prompt in settings sections without disclosing workspace inventory", () => {

--- a/main/services/assistant/system-prompt.ts
+++ b/main/services/assistant/system-prompt.ts
@@ -2,6 +2,8 @@
 // contract that matters most — that unattended runs carry the [SILENT] rule and
 // attended ones do not — is unit-testable.
 
+import { RESPONSE_FORMAT_GUIDANCE } from "../response-format-guidance.js";
+
 export interface AssistantPromptInput {
   /** Settings section ids the assistant may talk about. */
   settingsSections: readonly string[];
@@ -324,8 +326,9 @@ export function buildAssistantSystemPrompt(input: AssistantPromptInput): string 
       : []),
     telegram
       ? "Be concise and direct. Use Markdown sparingly and never open with a preamble about what you are about to do."
-      : "Be brief — this is a small window. Use Markdown sparingly and never open with a",
+      : "Be brief — this is a small window. Use Markdown purposefully and never open with a",
     ...(telegram ? [] : ["preamble about what you are about to do."]),
+    RESPONSE_FORMAT_GUIDANCE,
   ].join("\n");
   const surfacedPrompt = telegram
     ? withTelegramAgentContract(prompt, { workspaceBound: false })

--- a/main/services/llm-client.ts
+++ b/main/services/llm-client.ts
@@ -131,6 +131,7 @@ import {
 import { ToolApprovalCoordinator } from "./tool-approval.js";
 import { chatMessageToPiMessage, chatUserTextWithAttachments } from "./generation-messages.js";
 import { createPiCompactionModels, type PiCompactionEvent } from "./pi-compaction-core.js";
+import { PI_CHAT_SYSTEM_PROMPT } from "./response-format-guidance.js";
 import {
   beginPiVisibleTurnLease,
   piCompactionSessionStore,
@@ -523,8 +524,7 @@ async function buildSystemPrompt(
   skillSnapshot?: SkillRegistrySnapshot,
   availableToolNames?: ReadonlySet<string>,
 ): Promise<string> {
-  const base =
-    "You are Pi, a capable AI assistant. Respond clearly and concisely, using Markdown for formatting and fenced code blocks for code.";
+  const base = PI_CHAT_SYSTEM_PROMPT;
   const skillsText =
     skillsAvailable && skillSnapshot
       ? formatAvailableSkills(skillSnapshot, availableToolNames)

--- a/main/services/response-format-guidance.ts
+++ b/main/services/response-format-guidance.ts
@@ -1,0 +1,10 @@
+/** Shared editorial guidance for every conversational Aiden surface. */
+export const RESPONSE_FORMAT_GUIDANCE = [
+  "Use short paragraphs for explanation.",
+  "Use bullets for genuinely parallel items or steps, and numbered lists only when order matters.",
+  "Use headings only when a longer response benefits from sections.",
+  "Use bold lead-ins sparingly, and do not turn every response into a checklist.",
+].join(" ");
+
+export const PI_CHAT_SYSTEM_PROMPT =
+  `You are Pi, a capable AI assistant. Respond clearly and concisely, using Markdown for formatting and fenced code blocks for code. ${RESPONSE_FORMAT_GUIDANCE}`;

--- a/renderer/components/assistant/assistant-ui.test.tsx
+++ b/renderer/components/assistant/assistant-ui.test.tsx
@@ -33,7 +33,10 @@ test("Aiden replies use the main chat Markdown renderer", () => {
     <AssistantThread
       messages={[
         { role: "user", content: "Show me a list" },
-        { role: "assistant", content: "**Key directories**\n\n- `src`\n- `tests`" },
+        {
+          role: "assistant",
+          content: "A short paragraph.\n\n**Key directories**\n\n- `src`\n- `tests`\n\n1. Inspect\n2. Verify",
+        },
       ]}
       streaming={false}
       streamComplete={false}
@@ -42,8 +45,14 @@ test("Aiden replies use the main chat Markdown renderer", () => {
     />,
   );
   assert.match(html, /<strong>Key directories<\/strong>/u);
+  assert.match(html, /<p>A short paragraph\.<\/p>/u);
   assert.match(html, /<ul>/u);
+  assert.match(html, /<ol>/u);
   assert.match(html, /<code[^>]*>src<\/code>/u);
+  assert.match(html, /text-\[calc\(var\(--ui-font-size\)\+1px\)\]/u);
+  assert.match(html, /leading-\[1\.56\]/u);
+  assert.match(html, /\[&amp;_p\]:max-w-\[72ch\]/u);
+  assert.match(html, /\[&amp;_li\]:my-1\.5/u);
   assert.doesNotMatch(html, /\*\*Key directories\*\*/u);
 });
 

--- a/renderer/components/markdown.tsx
+++ b/renderer/components/markdown.tsx
@@ -16,16 +16,19 @@ interface MarkdownProps {
 }
 
 export const MARKDOWN_CLASSNAME = cn(
-  "select-text text-regular text-primary leading-relaxed",
+  // Chat prose gets its own readable scale instead of inflating controls,
+  // navigation, and settings through the global UI font-size preference.
+  "select-text text-[calc(var(--ui-font-size)+1px)] leading-[1.56] text-primary",
   // Model output routinely contains unbroken runs (URLs, base64, hashes). Wrap
   // them instead of letting one token widen the transcript column. KaTeX lays
   // out its own boxes and scrolls horizontally, so it opts back out.
   "break-words [&_.katex]:break-normal",
-  "[&_p]:my-2 first:[&_p]:mt-0 last:[&_p]:mb-0",
-  "[&_h1]:text-large-strong [&_h2]:text-strong [&_h3]:text-strong [&_h1]:mt-4 [&_h2]:mt-4 [&_h3]:mt-3 [&_h1]:mb-2 [&_h2]:mb-2 [&_h3]:mb-1",
-  "[&_ul]:my-2 [&_ul]:pl-5 [&_ul]:list-disc [&_ol]:my-2 [&_ol]:pl-5 [&_ol]:list-decimal [&_li]:my-0.5",
+  "[&_p]:my-3 [&_p]:max-w-[72ch] first:[&_p]:mt-0 last:[&_p]:mb-0",
+  "[&_h1]:max-w-[72ch] [&_h2]:max-w-[72ch] [&_h3]:max-w-[72ch] [&_h1]:text-[1.22em] [&_h2]:text-[1.12em] [&_h3]:text-[1em] [&_h1]:font-semibold [&_h2]:font-semibold [&_h3]:font-semibold [&_h1]:mt-6 [&_h2]:mt-5 [&_h3]:mt-4 [&_h1]:mb-2 [&_h2]:mb-2 [&_h3]:mb-1.5",
+  "[&_strong]:font-semibold",
+  "[&_ul]:my-3 [&_ul]:max-w-[72ch] [&_ul]:pl-6 [&_ul]:list-disc [&_ol]:my-3 [&_ol]:max-w-[72ch] [&_ol]:pl-6 [&_ol]:list-decimal [&_li]:my-1.5 [&_li>ul]:my-1.5 [&_li>ol]:my-1.5",
   "[&_a]:text-accent [&_a]:underline [&_a]:underline-offset-2",
-  "[&_blockquote]:border-l-2 [&_blockquote]:border-separator [&_blockquote]:pl-3 [&_blockquote]:text-secondary [&_blockquote]:my-2",
+  "[&_blockquote]:my-3 [&_blockquote]:max-w-[72ch] [&_blockquote]:border-l-2 [&_blockquote]:border-separator [&_blockquote]:pl-3.5 [&_blockquote]:text-secondary",
   "[&_table]:my-2 [&_table]:w-full [&_table]:block [&_table]:overflow-x-auto [&_th]:text-left [&_th]:border-b [&_th]:border-separator [&_th]:py-1 [&_th]:px-2 [&_td]:py-1 [&_td]:px-2 [&_td]:border-b [&_td]:border-separator/50",
   "[&_hr]:my-3 [&_hr]:border-separator",
   "[&_.katex-display]:my-3 [&_.katex-display]:overflow-x-auto [&_.katex-display]:overflow-y-hidden [&_.katex-display]:py-1",

--- a/renderer/components/streaming-markdown-reveal.tsx
+++ b/renderer/components/streaming-markdown-reveal.tsx
@@ -112,7 +112,7 @@ export function StreamingMarkdownReveal({
       {visible.map((block) => {
         if (block.kind === "prose") {
           return (
-            <p key={block.id} className="my-2 first:mt-0 last:mb-0">
+            <p key={block.id} className="my-3 max-w-[72ch] first:mt-0 last:mb-0">
               {block.units.map((unit) => {
                 const parts = splitStreamingRevealUnit(unit.text);
                 return (


### PR DESCRIPTION
## Summary
- add shared response-format guidance to both Pi chat and assistant system prompts
- favor short paragraphs and purposeful lists/headings
- add transcript-specific typography with a 72ch prose measure and improved list spacing
- keep final and streaming response geometry aligned

## Verification
- `npx tsx --test main/services/assistant/system-prompt.test.ts renderer/components/assistant/assistant-ui.test.tsx renderer/components/message-bubble.test.tsx renderer/lib/streaming-reveal.test.ts` (48 passed)
- `npm run type-check`
- `npm run lint`
- `git diff --check`

## Stack
Based on #49 so this PR contains only the response-formatting changes.