### PR TITLE
chore(release): start 0.34 line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-agent",
-  "version": "0.32.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-agent",
-      "version": "0.32.0",
+      "version": "0.34.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-agent",
-  "version": "0.32.0",
+  "version": "0.34.0",
   "private": true,
   "description": "A macOS AI workspace agent for local and hosted models",
   "keywords": [


### PR DESCRIPTION
## Summary
- move the desktop release line from 0.32 to 0.34
- keep package.json and package-lock.json in sync
- publish exactly v0.34.0 on the first enabled main release run

## Verification
- node scripts/prepare-ci-release.mjs 999 false -> 0.34.0
- npm run test:branding
- npm run type-check
- npm run test:model-pad (56 passing)
- npm run test:voice (20 passing)