### PR TITLE
chore(release): publish 0.34.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-agent",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-agent",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",
         "@earendil-works/pi-ai": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-agent",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "private": true,
   "description": "A macOS AI workspace agent for local and hosted models",
   "keywords": [


### PR DESCRIPTION
## Summary
- set the coordinated desktop release version to 0.34.1
- keep package.json and package-lock.json in sync
- publish exactly v0.34.1 when the release workflow runs

## Included changes
- #56 Gemini voice setup and dictation hardening
- #57 Remote dev port isolation and Tailscale inspection
- #58 onboarding credential flows for all eligible providers

## Verification
- git diff --check
- PR CI (pending)
- local test:branding unavailable because dependencies are not installed in this worktree