### PR TITLE
Refine composer and palette controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ tmp/*
 
 # Local git worktrees
 .worktrees/
+
+learnings.md

--- a/renderer/components/command-palette.tsx
+++ b/renderer/components/command-palette.tsx
@@ -17,18 +17,9 @@ import {
   Server,
   Settings,
   Sun,
-  TerminalSquare,
   Wrench,
 } from "lucide-react";
-import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-  toast,
-} from "./ui";
+import { Command, CommandEmpty, CommandInput, CommandItem, CommandList, toast } from "./ui";
 import { cn } from "../lib/ui-utils";
 import {
   COMMANDS,
@@ -45,10 +36,7 @@ import {
 import { useChats, useProviders, useSettings, queryKeys } from "../lib/queries";
 import { useActiveWorkspace } from "../lib/workspace-context";
 import { providersApi, settingsApi } from "../lib/ipc";
-import {
-  readModelSelectionRevision,
-  useModelSelection,
-} from "../lib/use-model-selection";
+import { readModelSelectionRevision, useModelSelection } from "../lib/use-model-selection";
 import { createModelEntries, isUsable, visibleModelEntries } from "../lib/model-picker-data";
 import { SETTINGS_DESTINATIONS } from "../lib/settings-section";
 import {
@@ -91,7 +79,7 @@ function Shortcut({ commandId }: { commandId: CommandId }) {
   const value = binding(commandId);
   if (!value) return null;
   return (
-    <kbd className="ml-auto shrink-0 rounded-md border border-separator bg-control/55 px-1.5 py-0.5 font-sans text-mini text-secondary">
+    <kbd className="ml-auto shrink-0 rounded-md bg-control/55 px-1.5 py-0.5 font-sans text-mini text-secondary">
       {prettyAccelerator(value)}
     </kbd>
   );
@@ -132,10 +120,12 @@ export function AppCommandPalette({
   });
   const models = React.useMemo(
     () =>
-      settings.data ? visibleModelEntries(
-        createModelEntries(providers.data ?? []),
-        settings.data?.hiddenModelsByProvider,
-      ) : [],
+      settings.data
+        ? visibleModelEntries(
+            createModelEntries(providers.data ?? []),
+            settings.data?.hiddenModelsByProvider,
+          )
+        : [],
     [providers.data, settings.data?.hiddenModelsByProvider],
   );
   const unavailableModelProviders = React.useMemo(
@@ -270,9 +260,7 @@ export function AppCommandPalette({
           const currentSettings = await settingsApi.get();
           if (!isCurrent()) return;
           previousAppearance = normalizeAppearanceConfig(
-            readCachedAppearance() ??
-              currentSettings.appearance ??
-              createDefaultAppearanceConfig(),
+            readCachedAppearance() ?? currentSettings.appearance ?? createDefaultAppearanceConfig(),
           );
           const appearance = {
             ...previousAppearance,
@@ -360,7 +348,7 @@ export function AppCommandPalette({
           data-slot="dialog-content"
           data-command-palette-content
           aria-describedby={undefined}
-          className="fixed left-1/2 top-[16vh] z-50 w-[min(92vw,640px)] -translate-x-1/2 overflow-hidden rounded-dialog bg-popover shadow-modal outline-none"
+          className="fixed left-1/2 top-[16vh] z-50 w-[min(92vw,640px)] -translate-x-1/2 overflow-hidden rounded-[22px] bg-popover shadow-modal outline-none"
           onOpenAutoFocus={(event) => {
             event.preventDefault();
             requestAnimationFrame(() =>
@@ -376,8 +364,8 @@ export function AppCommandPalette({
           <DialogPrimitive.Title className="sr-only">
             {MODE_LABELS[palette.mode]}
           </DialogPrimitive.Title>
-          <Command className="min-h-[420px]">
-            <div className="flex h-10 items-center border-b border-separator px-3">
+          <Command className="min-h-[420px] [&_[cmdk-item][data-selected=true]]:bg-control">
+            <div className="flex h-10 items-center px-3">
               {palette.mode === "root" ? (
                 <span className="mr-2 flex size-6 items-center justify-center rounded-md bg-control text-secondary">
                   <Keyboard className="size-3.5" />
@@ -403,6 +391,8 @@ export function AppCommandPalette({
             </div>
             <CommandInput
               data-command-palette-input
+              containerClassName="px-4"
+              showSeparator={false}
               value={query}
               onValueChange={setQuery}
               placeholder={
@@ -466,7 +456,7 @@ export function AppCommandPalette({
                     onSelect={() => runCommand("chat.new")}
                     disabled={!canExecute("chat.new")}
                     aria-keyshortcuts={ariaKeyShortcut(binding("chat.new"))}
-                    className="min-h-11 px-3"
+                    className="mb-1 min-h-11 px-3"
                   >
                     <MessageSquare className="size-4 text-secondary" />
                     <span>New chat</span>
@@ -476,9 +466,13 @@ export function AppCommandPalette({
                       <ItemDetail>Open a workspace first</ItemDetail>
                     )}
                   </CommandItem>
-                  <CommandSeparator />
                   {chats.isLoading ? (
-                    <CommandItem forceMount disabled value="Loading chats" className="min-h-11 px-3">
+                    <CommandItem
+                      forceMount
+                      disabled
+                      value="Loading chats"
+                      className="min-h-11 px-3"
+                    >
                       <RefreshCw className="size-4 animate-spin text-secondary" />
                       <span>Loading chats…</span>
                     </CommandItem>
@@ -512,77 +506,77 @@ export function AppCommandPalette({
                 </>
               ) : null}
 
-              {palette.mode === "models"
-                ? providers.isLoading ? (
-                    <CommandItem forceMount disabled value="Loading models" className="min-h-11 px-3">
-                      <RefreshCw className="size-4 animate-spin text-secondary" />
-                      <span>Loading models…</span>
-                    </CommandItem>
-                  ) : providers.isError ? (
-                    <CommandItem
-                      forceMount
-                      value="Retry loading models"
-                      onSelect={() => void providers.refetch()}
-                      className="min-h-11 px-3"
-                    >
-                      <RefreshCw className="size-4 text-secondary" />
-                      <span>Models could not be loaded</span>
-                      <ItemDetail>Retry</ItemDetail>
-                    </CommandItem>
-                  ) : models.map((entry) => {
-                    const selected =
-                      selection.providerId === entry.providerId && selection.model === entry.model;
-                    return (
-                      <CommandItem
-                        key={entry.value}
-                        value={`${entry.label} ${entry.model} ${entry.providerLabel}`}
-                        onSelect={() => void selectModel(entry.providerId, entry.model)}
-                        disabled={busy}
-                        aria-current={selected ? "true" : undefined}
-                        className="min-h-11 px-3"
-                      >
-                        <Bot className="size-4 shrink-0 text-secondary" />
-                        <span className="min-w-0 flex-1 truncate">{entry.label}</span>
-                        <ItemDetail>{entry.providerLabel}</ItemDetail>
-                        {selected ? (
-                          <>
-                            <span className="sr-only">Current</span>
-                            <Check
-                              aria-hidden="true"
-                              className="size-4 shrink-0 text-accent"
-                            />
-                          </>
-                        ) : null}
-                      </CommandItem>
-                    );
-                  }).concat(
-                    unavailableModelProviders.map((provider) => (
-                      <CommandItem
-                        key={`unavailable-${provider.id}`}
-                        value={`${provider.label} ${provider.models.join(" ")} unavailable setup provider`}
-                        onSelect={() => {
-                          if (!allowNavigation()) return;
-                          rememberCommand("model.change");
-                          close();
-                          void navigate({
-                            to: "/settings",
-                            search: { section: "providers" },
-                          });
-                        }}
-                        className="min-h-11 px-3"
-                      >
-                        <Server className="size-4 shrink-0 text-secondary" />
-                        <span className="min-w-0 flex-1 truncate">
-                          {provider.label} models
-                        </span>
-                        <ItemDetail>
-                          {provider.models.length > 0 ? "Setup needed" : "No models available"}
-                        </ItemDetail>
-                        <ChevronRight className="size-4 shrink-0 text-tertiary" />
-                      </CommandItem>
-                    )),
-                  )
-                : null}
+              {palette.mode === "models" ? (
+                providers.isLoading ? (
+                  <CommandItem forceMount disabled value="Loading models" className="min-h-11 px-3">
+                    <RefreshCw className="size-4 animate-spin text-secondary" />
+                    <span>Loading models…</span>
+                  </CommandItem>
+                ) : providers.isError ? (
+                  <CommandItem
+                    forceMount
+                    value="Retry loading models"
+                    onSelect={() => void providers.refetch()}
+                    className="min-h-11 px-3"
+                  >
+                    <RefreshCw className="size-4 text-secondary" />
+                    <span>Models could not be loaded</span>
+                    <ItemDetail>Retry</ItemDetail>
+                  </CommandItem>
+                ) : (
+                  models
+                    .map((entry) => {
+                      const selected =
+                        selection.providerId === entry.providerId &&
+                        selection.model === entry.model;
+                      return (
+                        <CommandItem
+                          key={entry.value}
+                          value={`${entry.label} ${entry.model} ${entry.providerLabel}`}
+                          onSelect={() => void selectModel(entry.providerId, entry.model)}
+                          disabled={busy}
+                          aria-current={selected ? "true" : undefined}
+                          className="min-h-11 px-3"
+                        >
+                          <Bot className="size-4 shrink-0 text-secondary" />
+                          <span className="min-w-0 flex-1 truncate">{entry.label}</span>
+                          <ItemDetail>{entry.providerLabel}</ItemDetail>
+                          {selected ? (
+                            <>
+                              <span className="sr-only">Current</span>
+                              <Check aria-hidden="true" className="size-4 shrink-0 text-accent" />
+                            </>
+                          ) : null}
+                        </CommandItem>
+                      );
+                    })
+                    .concat(
+                      unavailableModelProviders.map((provider) => (
+                        <CommandItem
+                          key={`unavailable-${provider.id}`}
+                          value={`${provider.label} ${provider.models.join(" ")} unavailable setup provider`}
+                          onSelect={() => {
+                            if (!allowNavigation()) return;
+                            rememberCommand("model.change");
+                            close();
+                            void navigate({
+                              to: "/settings",
+                              search: { section: "providers" },
+                            });
+                          }}
+                          className="min-h-11 px-3"
+                        >
+                          <Server className="size-4 shrink-0 text-secondary" />
+                          <span className="min-w-0 flex-1 truncate">{provider.label} models</span>
+                          <ItemDetail>
+                            {provider.models.length > 0 ? "Setup needed" : "No models available"}
+                          </ItemDetail>
+                          <ChevronRight className="size-4 shrink-0 text-tertiary" />
+                        </CommandItem>
+                      )),
+                    )
+                )
+              ) : null}
 
               {palette.mode === "providers" ? (
                 <>
@@ -590,14 +584,18 @@ export function AppCommandPalette({
                     value="Refresh provider model catalogs update"
                     onSelect={() => void refreshProviders()}
                     disabled={busy}
-                    className="min-h-11 px-3"
+                    className="mb-1 min-h-11 px-3"
                   >
                     <RefreshCw className={cn("size-4 text-secondary", busy && "animate-spin")} />
                     <span>{busy ? "Refreshing providers…" : "Refresh provider catalogs"}</span>
                   </CommandItem>
-                  <CommandSeparator />
                   {providers.isLoading ? (
-                    <CommandItem forceMount disabled value="Loading providers" className="min-h-11 px-3">
+                    <CommandItem
+                      forceMount
+                      disabled
+                      value="Loading providers"
+                      className="min-h-11 px-3"
+                    >
                       <RefreshCw className="size-4 animate-spin text-secondary" />
                       <span>Loading providers…</span>
                     </CommandItem>
@@ -645,29 +643,25 @@ export function AppCommandPalette({
                     { mode: "system" as const, title: "Follow macOS appearance", icon: Palette },
                     { mode: "light" as const, title: "Use light appearance", icon: Sun },
                     { mode: "dark" as const, title: "Use dark appearance", icon: Moon },
-                  ].map((item) => (
+                  ].map((item, index) => (
                     <CommandItem
                       key={item.mode}
                       value={`${item.title} theme appearance`}
                       onSelect={() => void setAppearance(item.mode)}
                       disabled={busy}
                       aria-current={appearanceMode === item.mode ? "true" : undefined}
-                      className="min-h-11 px-3"
+                      className={cn("min-h-11 px-3", index === 2 && "mb-1")}
                     >
                       <item.icon className="size-4 text-secondary" />
                       <span>{item.title}</span>
                       {appearanceMode === item.mode ? (
                         <>
                           <span className="sr-only">Current</span>
-                          <Check
-                            aria-hidden="true"
-                            className="ml-auto size-4 text-accent"
-                          />
+                          <Check aria-hidden="true" className="ml-auto size-4 text-accent" />
                         </>
                       ) : null}
                     </CommandItem>
                   ))}
-                  <CommandSeparator />
                   {SETTINGS_DESTINATIONS.map((destination) => (
                     <CommandItem
                       key={destination.id}
@@ -691,14 +685,6 @@ export function AppCommandPalette({
                 </>
               ) : null}
             </CommandList>
-            <div className="flex h-9 items-center gap-3 border-t border-separator px-3 text-mini text-tertiary">
-              <span>↑↓ Navigate</span>
-              <span>↩ Run</span>
-              <span className="ml-auto flex items-center gap-1">
-                <TerminalSquare className="size-3.5" />
-                Local app actions
-              </span>
-            </div>
           </Command>
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>

--- a/renderer/components/composer-slash-palette.tsx
+++ b/renderer/components/composer-slash-palette.tsx
@@ -178,12 +178,11 @@ export function ComposerSlashPalette({
   const row = (result: SlashResult, available: boolean, unavailableReason?: string) => {
     const selected = result.id === activeId;
     const Icon = result.kind === "command" ? ICONS[result.command.icon] : AidenIcon;
-    const title = result.kind === "command" ? `/${result.command.name}` : `$${result.skill.name}`;
+    const title = result.kind === "command" ? result.command.title : `$${result.skill.name}`;
     const description =
       result.kind === "command" ? result.command.description : result.skill.description;
-    const detail =
-      unavailableReason ??
-      (result.kind === "skill" ? sourceLabel(result.skill.source) : result.command.title);
+    const metadata = result.kind === "skill" ? sourceLabel(result.skill.source) : "";
+    const detail = unavailableReason ?? description;
     const reasonId = unavailableReason ? `${result.id}-unavailable-reason` : undefined;
     return (
       <div
@@ -201,29 +200,29 @@ export function ComposerSlashPalette({
           else if (unavailableReason) setAnnouncement(unavailableReason);
         }}
         className={cn(
-          "flex min-h-12 cursor-default items-center gap-2.5 rounded-lg px-2.5 py-2 outline-none transition-colors duration-100",
-          selected && available && "bg-list-selection",
+          "flex min-h-10 cursor-default items-center gap-2 rounded-[10px] px-2.5 py-1.5 outline-none transition-colors duration-100",
+          selected && available && "bg-control",
           !selected && available && "hover:bg-list-hover",
-          !available && "opacity-50",
+          !available && "opacity-45",
         )}
       >
-        <span className="grid size-7 shrink-0 place-items-center text-secondary">
-          <Icon aria-hidden="true" className="size-4" />
+        <span
+          className={cn(
+            "grid size-7 shrink-0 place-items-center text-secondary transition-colors duration-100",
+            selected && available && "text-primary",
+          )}
+        >
+          <Icon aria-hidden="true" className="size-[18px]" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="flex min-w-0 items-baseline gap-2">
-            <span className="truncate text-regular-strong text-primary">{title}</span>
-            {result.kind === "command" && result.command.aliases.length > 0 ? (
-              <span className="truncate text-mini text-tertiary">
-                {result.command.aliases.map((alias) => `/${alias}`).join(" · ")}
-              </span>
-            ) : null}
-          </span>
-          <span className="block truncate text-small text-secondary">{description}</span>
+        <span className="flex min-w-0 flex-1 items-baseline gap-2">
+          <span className="truncate text-regular-strong text-primary">{title}</span>
+          {metadata ? (
+            <span className="max-w-28 truncate text-small text-tertiary">{metadata}</span>
+          ) : null}
         </span>
         <span
           aria-hidden={unavailableReason ? "true" : undefined}
-          className="composer-slash-detail max-w-40 shrink-0 truncate text-right text-mini text-tertiary max-[520px]:hidden"
+          className="composer-slash-detail ml-auto min-w-0 max-w-[58%] truncate text-right text-small text-tertiary max-[520px]:hidden"
         >
           {detail}
         </span>
@@ -238,7 +237,7 @@ export function ComposerSlashPalette({
 
   return (
     <div
-      className="composer-slash-palette absolute inset-x-3 bottom-full z-40 mb-2 origin-bottom overflow-hidden rounded-popover border border-separator bg-popover/98 shadow-popover backdrop-blur-xl"
+      className="composer-slash-palette absolute inset-x-3 bottom-full z-40 mb-2 origin-bottom overflow-hidden rounded-dialog border border-separator bg-popover/98 shadow-popover backdrop-blur-xl"
       data-composer-slash-palette
       data-presence={presenceState}
       aria-hidden={presenceState === "exiting" ? "true" : undefined}
@@ -247,7 +246,7 @@ export function ComposerSlashPalette({
         id={COMPOSER_SLASH_PALETTE_ID}
         role="listbox"
         aria-label={mode === "command" ? "Slash commands" : "Skills"}
-        className="max-h-[min(22rem,48vh)] overflow-y-auto overscroll-contain p-1.5 [mask-image:linear-gradient(to_bottom,transparent_0,black_0.35rem,black_calc(100%_-_0.35rem),transparent_100%)]"
+        className="max-h-[min(24rem,52vh)] overflow-y-auto overscroll-contain p-2 [mask-image:linear-gradient(to_bottom,transparent_0,black_0.4rem,black_calc(100%_-_0.4rem),transparent_100%)]"
       >
         {mode === "command" ? (
           <div>

--- a/renderer/components/composer.test.tsx
+++ b/renderer/components/composer.test.tsx
@@ -28,13 +28,22 @@ test("composer context controls stay compact without exposing provider copy", ()
   const composer = source("./composer.tsx");
   const modelPicker = source("./model-picker.tsx");
 
-  assert.match(composer, /h-7 gap-1\.5 px-2 max-\[520px\]:size-7 max-\[520px\]:px-0/u);
-  assert.match(
-    composer,
-    /<span className="composer-permission-label max-\[520px\]:hidden">\s*\{permissionSaving \? "Updating…" : perm\.label\}/u,
-  );
+  assert.match(composer, /group\/access relative h-8 w-34/u);
+  assert.match(composer, /role="radiogroup"\s*aria-label="Workspace access"/u);
+  assert.match(composer, /absolute bottom-full left-0/u);
+  assert.match(composer, /group-hover\/access:visible/u);
+  assert.match(composer, /group-focus-within\/access:visible/u);
+  assert.match(composer, /group-data-\[open=true\]\/access:visible/u);
+  assert.match(composer, /bg-control\/80/u);
+  assert.match(composer, /selected\s*\? "bg-popover shadow-control"/u);
+  assert.doesNotMatch(composer, /group-hover\/access:max-h/u);
+  assert.match(composer, /aria-disabled=\{disabled \|\| undefined\}/u);
+  assert.doesNotMatch(composer, /group\/access[^\n]*disabled:opacity-45/u);
+  assert.doesNotMatch(composer, /DropdownMenuCheckboxItem/u);
+  assert.doesNotMatch(composer, /<DropdownMenuLabel>Workspace access/u);
   assert.match(modelPicker, /\? selected\.label\s*: hasUnavailableSelection/u);
   assert.match(modelPicker, /`Selected model: \$\{selected\.label\}\. Choose a model\.`/u);
+  assert.doesNotMatch(modelPicker, /ChevronsUpDown/u);
   assert.doesNotMatch(modelPicker, /Selected model: \$\{selected\.label\} from/u);
   assert.doesNotMatch(modelPicker, /\$\{selected\.label\} · \$\{selected\.providerLabel\}/u);
 });
@@ -102,6 +111,15 @@ test("composer slash palette is an overlaid textarea-owned accessible listbox", 
   assert.match(palette, /onPointerDown=\{\(event\) => event\.preventDefault\(\)\}/u);
   assert.match(palette, /motion-reduce:animate-none/u);
   assert.match(palette, /max-\[520px\]:hidden/u);
+  assert.match(palette, /flex min-h-10/u);
+  assert.match(palette, /selected && available && "bg-control"/u);
+  assert.match(palette, /result\.command\.title/u);
+  assert.doesNotMatch(palette, /`\/\$\{result\.command\.name\}`/u);
+  assert.doesNotMatch(palette, /`\/\$\{alias\}`/u);
+  assert.match(palette, /const detail = unavailableReason \?\? description/u);
+  assert.match(palette, /rounded-dialog border border-separator/u);
+  assert.doesNotMatch(palette, /block truncate text-small text-secondary/u);
+  assert.doesNotMatch(palette, /selected && available && "bg-list-selection"/u);
   assert.doesNotMatch(palette, /Commands and skills/u);
   assert.doesNotMatch(palette, /composer-slash-shortcuts/u);
   assert.doesNotMatch(palette, /rounded-md bg-control\/65 text-secondary/u);

--- a/renderer/components/composer.test.tsx
+++ b/renderer/components/composer.test.tsx
@@ -214,3 +214,13 @@ test("workspace picker closes and exposes a persistent reason when workspace cha
   assert.match(picker, /disabled=\{pending !== null \|\| Boolean\(blockedReason\)\}/u);
   assert.match(picker, /!pending && !blockedReason && setOpen\(nextOpen\)/u);
 });
+
+test("workspace access keyboard navigation moves focus without changing permission", () => {
+  const composer = source("./composer.tsx");
+  assert.match(
+    composer,
+    /event\.key === "Enter" \|\| event\.key === " "\) \{\s*event\.preventDefault\(\);\s*if \(value !== permission\) requestPermission\(value\);/u,
+  );
+  assert.match(composer, /radios\?\.\[nextIndex\]\?\.focus\(\)/u);
+  assert.doesNotMatch(composer, /requestPermission\(nextPermission\)/u);
+});

--- a/renderer/components/composer.tsx
+++ b/renderer/components/composer.tsx
@@ -1617,6 +1617,11 @@ export function Composer({
                           }}
                           onKeyDown={(event) => {
                             if (disabled) return;
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              if (value !== permission) requestPermission(value);
+                              return;
+                            }
                             let nextIndex: number | undefined;
                             if (event.key === "ArrowDown" || event.key === "ArrowRight") {
                               nextIndex = (index + 1) % PERMISSION_ORDER.length;
@@ -1629,8 +1634,6 @@ export function Composer({
                             if (event.key === "End") nextIndex = PERMISSION_ORDER.length - 1;
                             if (nextIndex === undefined) return;
                             event.preventDefault();
-                            const nextPermission = PERMISSION_ORDER[nextIndex];
-                            if (nextPermission !== permission) requestPermission(nextPermission);
                             const radios =
                               event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>(
                                 '[role="radio"]',

--- a/renderer/components/composer.tsx
+++ b/renderer/components/composer.tsx
@@ -10,11 +10,8 @@ import {
   Button,
   Dialog,
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
   Textarea,
@@ -178,30 +175,27 @@ const PERMISSION_META: Record<
   WorkspacePermission,
   {
     label: string;
-    description: string;
     icon: React.ComponentType<{ className?: string }>;
     className: string;
   }
 > = {
   full: {
     label: "Full access",
-    description: "Read and edit files, and run commands without asking.",
     icon: OctagonAlert,
     className: "text-support-warning",
   },
   ask: {
     label: "Ask first",
-    description: "Read freely; confirm every edit and command.",
     icon: ShieldQuestion,
     className: "text-secondary",
   },
   none: {
     label: "No access",
-    description: "Keep workspace files and commands unavailable.",
     icon: Lock,
     className: "text-tertiary",
   },
 };
+const PERMISSION_ORDER: readonly WorkspacePermission[] = ["full", "ask", "none"];
 
 function skillSourceLabel(source: SkillSource): string {
   return source === "configured" ? "Configured" : source === "workspace" ? "Workspace" : "Global";
@@ -325,6 +319,7 @@ export function Composer({
   const [permissionSaving, setPermissionSaving] = React.useState(false);
   const [confirmFullAccess, setConfirmFullAccess] = React.useState(false);
   const [permissionMenuOpen, setPermissionMenuOpen] = React.useState(false);
+  const permissionControlRef = React.useRef<HTMLButtonElement>(null);
   const [renameDialogOpen, setRenameDialogOpen] = React.useState(false);
   const [renameTitle, setRenameTitle] = React.useState("");
   const [renaming, setRenaming] = React.useState(false);
@@ -741,7 +736,10 @@ export function Composer({
           toast.success("Latest response copied");
         },
         openReview: () => onOpenReview?.(),
-        openAccess: () => setPermissionMenuOpen(true),
+        openAccess: () => {
+          setPermissionMenuOpen(true);
+          requestAnimationFrame(() => permissionControlRef.current?.focus());
+        },
         openFork: () => {
           setForkQuery("");
           setForkDialogOpen(true);
@@ -1151,8 +1149,7 @@ export function Composer({
   };
 
   const permission = workspace?.permission ?? "ask";
-  const perm = PERMISSION_META[permission];
-  const PermIcon = perm.icon;
+  const PermissionIcon = PERMISSION_META[permission].icon;
   const folderName = workspace?.folderPath
     ? workspace.folderPath.split("/").filter(Boolean).pop()
     : workspace?.name;
@@ -1199,6 +1196,7 @@ export function Composer({
       gitOperationBusy
     )
       return;
+    setPermissionMenuOpen(false);
     if (nextPermission === "full") {
       setConfirmFullAccess(true);
       return;
@@ -1535,86 +1533,124 @@ export function Composer({
                 <span className="sr-only" role="status" aria-live="polite">
                   {attachmentStatus}
                 </span>
-                <DropdownMenu
-                  open={permissionMenuOpen}
-                  onOpenChange={(open) => {
-                    setPermissionMenuOpen(open);
-                    if (open) {
-                      dismissSlash();
+                <div
+                  className="composer-permission-control group/access relative h-8 w-34 shrink-0 max-[520px]:w-8"
+                  data-open={permissionMenuOpen || undefined}
+                  onPointerEnter={dismissSlash}
+                  onPointerLeave={() => setPermissionMenuOpen(false)}
+                  onBlur={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget)) {
+                      setPermissionMenuOpen(false);
                     }
                   }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Escape") return;
+                    event.preventDefault();
+                    setPermissionMenuOpen(false);
+                    inputRef?.current?.focus();
+                  }}
                 >
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="transparent"
-                      size="small"
-                      className={cn(
-                        "composer-permission-control h-7 gap-1.5 px-2 max-[520px]:size-7 max-[520px]:px-0",
-                        perm.className,
-                      )}
-                      disabled={
+                  <button
+                    type="button"
+                    aria-label={`Workspace access: ${PERMISSION_META[permission].label}. Show access options.`}
+                    aria-haspopup="true"
+                    onFocus={() => setPermissionMenuOpen(true)}
+                    onClick={() => setPermissionMenuOpen(true)}
+                    onKeyDown={(event) => {
+                      if (!["ArrowUp", "ArrowDown", "Enter", " "].includes(event.key)) return;
+                      event.preventDefault();
+                      setPermissionMenuOpen(true);
+                      requestAnimationFrame(() => permissionControlRef.current?.focus());
+                    }}
+                    className="absolute inset-0 flex items-center gap-2 overflow-hidden whitespace-nowrap rounded-pill bg-transparent px-3 text-regular outline-none transition-opacity duration-100 ease-out group-hover/access:opacity-0 group-focus-within/access:opacity-0 group-data-[open=true]/access:opacity-0 max-[520px]:justify-center max-[520px]:px-0"
+                  >
+                    <PermissionIcon
+                      className={cn("size-4 shrink-0", PERMISSION_META[permission].className)}
+                    />
+                    <span className="truncate max-[520px]:sr-only">
+                      {permissionSaving ? "Updating…" : PERMISSION_META[permission].label}
+                    </span>
+                  </button>
+                  <div
+                    role="radiogroup"
+                    aria-label="Workspace access"
+                    aria-disabled={
+                      !workspace ||
+                      permissionSaving ||
+                      isGenerating ||
+                      sending ||
+                      gitOperationBusy ||
+                      Boolean(workspaceChangeBlockedReason) ||
+                      undefined
+                    }
+                    className="invisible pointer-events-none absolute bottom-full left-0 z-20 flex min-w-34 translate-y-1 flex-col items-stretch overflow-hidden rounded-[16px] bg-control/80 p-1 opacity-0 shadow-control-hover transition-[opacity,transform,visibility] duration-100 ease-out group-hover/access:visible group-hover/access:pointer-events-auto group-hover/access:translate-y-0 group-hover/access:opacity-100 group-focus-within/access:visible group-focus-within/access:pointer-events-auto group-focus-within/access:translate-y-0 group-focus-within/access:opacity-100 group-data-[open=true]/access:visible group-data-[open=true]/access:pointer-events-auto group-data-[open=true]/access:translate-y-0 group-data-[open=true]/access:opacity-100"
+                  >
+                    {PERMISSION_ORDER.map((value, index) => {
+                      const meta = PERMISSION_META[value];
+                      const Icon = meta.icon;
+                      const selected = value === permission;
+                      const disabled =
                         !workspace ||
                         permissionSaving ||
                         isGenerating ||
                         sending ||
                         gitOperationBusy ||
-                        Boolean(workspaceChangeBlockedReason)
-                      }
-                      aria-label={
-                        workspaceChangeBlockedReason
-                          ? `Workspace access: ${perm.label}. ${workspaceChangeBlockedReason}.`
-                          : isGenerating || sending
-                            ? `Workspace access: ${perm.label}. Finish or stop the current response to change access.`
-                            : `Workspace access: ${perm.label}`
-                      }
-                    >
-                      <PermIcon className="size-4 shrink-0" />
-                      <span className="composer-permission-label max-[520px]:hidden">
-                        {permissionSaving ? "Updating…" : perm.label}
-                      </span>
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
-                    <DropdownMenuLabel>Workspace access</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuCheckboxItem
-                      checked={permission === "full"}
-                      sublabel={PERMISSION_META.full.description}
-                      disabled={
-                        permissionSaving ||
-                        gitOperationBusy ||
-                        Boolean(workspaceChangeBlockedReason)
-                      }
-                      onCheckedChange={(checked) => checked && requestPermission("full")}
-                    >
-                      Full access
-                    </DropdownMenuCheckboxItem>
-                    <DropdownMenuCheckboxItem
-                      checked={permission === "ask"}
-                      sublabel={PERMISSION_META.ask.description}
-                      disabled={
-                        permissionSaving ||
-                        gitOperationBusy ||
-                        Boolean(workspaceChangeBlockedReason)
-                      }
-                      onCheckedChange={(checked) => checked && requestPermission("ask")}
-                    >
-                      Ask first
-                    </DropdownMenuCheckboxItem>
-                    <DropdownMenuCheckboxItem
-                      checked={permission === "none"}
-                      sublabel={PERMISSION_META.none.description}
-                      disabled={
-                        permissionSaving ||
-                        gitOperationBusy ||
-                        Boolean(workspaceChangeBlockedReason)
-                      }
-                      onCheckedChange={(checked) => checked && requestPermission("none")}
-                    >
-                      No access
-                    </DropdownMenuCheckboxItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                        Boolean(workspaceChangeBlockedReason);
+                      return (
+                        <button
+                          ref={selected ? permissionControlRef : undefined}
+                          key={value}
+                          type="button"
+                          role="radio"
+                          aria-checked={selected}
+                          aria-label={
+                            workspaceChangeBlockedReason
+                              ? `Workspace access: ${meta.label}. ${workspaceChangeBlockedReason}.`
+                              : isGenerating || sending
+                                ? `Workspace access: ${meta.label}. Finish or stop the current response to change access.`
+                                : `Workspace access: ${meta.label}`
+                          }
+                          tabIndex={selected ? 0 : -1}
+                          aria-disabled={disabled || undefined}
+                          onClick={() => {
+                            if (!disabled) requestPermission(value);
+                          }}
+                          onKeyDown={(event) => {
+                            if (disabled) return;
+                            let nextIndex: number | undefined;
+                            if (event.key === "ArrowDown" || event.key === "ArrowRight") {
+                              nextIndex = (index + 1) % PERMISSION_ORDER.length;
+                            }
+                            if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
+                              nextIndex =
+                                (index - 1 + PERMISSION_ORDER.length) % PERMISSION_ORDER.length;
+                            }
+                            if (event.key === "Home") nextIndex = 0;
+                            if (event.key === "End") nextIndex = PERMISSION_ORDER.length - 1;
+                            if (nextIndex === undefined) return;
+                            event.preventDefault();
+                            const nextPermission = PERMISSION_ORDER[nextIndex];
+                            if (nextPermission !== permission) requestPermission(nextPermission);
+                            const radios =
+                              event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>(
+                                '[role="radio"]',
+                              );
+                            radios?.[nextIndex]?.focus();
+                          }}
+                          className={cn(
+                            "flex h-8 w-full items-center gap-2 overflow-hidden whitespace-nowrap rounded-pill px-3 text-regular outline-none transition-[background-color,box-shadow,color] duration-100 ease-out focus-visible:outline-none aria-disabled:cursor-default",
+                            selected
+                              ? "bg-popover shadow-control"
+                              : "hover:bg-list-hover active:bg-list-selection focus-visible:bg-list-selection",
+                          )}
+                        >
+                          <Icon className={cn("size-4 shrink-0", meta.className)} />
+                          <span className="truncate">{meta.label}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
                 {computerUse && onChangeComputerUse ? (
                   <Button
                     variant={computerUse.enabled ? "muted" : "transparent"}

--- a/renderer/components/model-picker.tsx
+++ b/renderer/components/model-picker.tsx
@@ -37,7 +37,7 @@ import {
   useModelPadLayout,
 } from "../lib/model-pad-layout";
 import type { ModelInfo, Provider } from "../lib/types";
-import { Check, ChevronsUpDown, Pin, SlidersHorizontal } from "lucide-react";
+import { Check, Pin, SlidersHorizontal } from "lucide-react";
 import { ProviderIcon } from "./provider-icon";
 import type { HiddenModelsByProvider } from "../shared/model-visibility";
 
@@ -522,7 +522,6 @@ export function ModelPicker({
                   ? "Select model"
                   : "No models"}
           </span>
-          <ChevronsUpDown className="size-3.5 shrink-0 text-tertiary" />
         </Button>
       </PopoverTrigger>
 

--- a/renderer/components/thinking-control.test.tsx
+++ b/renderer/components/thinking-control.test.tsx
@@ -14,15 +14,35 @@ test("renders an accessible four-step Gemini thinking control", () => {
   assert.match(markup, /role="radiogroup"/u);
   assert.match(markup, /aria-label="Gemini thinking level"/u);
   assert.equal((markup.match(/role="radio"/gu) ?? []).length, 4);
-  assert.match(
-    markup,
-    /aria-checked="true" aria-label="Thinking: medium effort" tabindex="0"/u,
-  );
+  assert.match(markup, /aria-checked="true" aria-label="Thinking: medium effort" tabindex="0"/u);
   assert.equal((markup.match(/tabindex="-1"/gu) ?? []).length, 3);
   assert.match(markup, />Off</u);
   assert.match(markup, />Low</u);
   assert.match(markup, />Med</u);
   assert.match(markup, />High</u);
+  assert.match(markup, /group\/thinking relative h-8 w-18/u);
+  assert.match(markup, /absolute bottom-0 right-0/u);
+  assert.match(markup, /flex-col items-stretch/u);
+  assert.match(markup, /pointer-events-none max-h-0/u);
+  assert.match(markup, /group-hover\/thinking:max-h-7/u);
+  assert.match(markup, /group-focus-within\/thinking:max-h-7/u);
+  assert.match(markup, /group-hover\/thinking:bg-control\/80/u);
+  assert.match(markup, /group-hover\/thinking:bg-popover/u);
+  assert.doesNotMatch(markup, /disabled:opacity-45/u);
+});
+
+test("keeps the active thinking option mounted and focusable while a change saves", () => {
+  const markup = renderToStaticMarkup(
+    <ThinkingControl
+      level="high"
+      levels={["low", "medium", "high"]}
+      disabled
+      onChange={() => undefined}
+    />,
+  );
+  assert.match(markup, /aria-disabled="true"/u);
+  assert.doesNotMatch(markup, / disabled=""/u);
+  assert.match(markup, /aria-checked="true"[^>]*tabindex="0"/u);
 });
 
 test("renders only distinct choices and identifies hidden minimum thinking", () => {
@@ -51,10 +71,7 @@ test("renders model-specific Codex effort levels without an off alias", () => {
   );
   assert.match(markup, /aria-label="Codex thinking level"/u);
   assert.equal((markup.match(/role="radio"/gu) ?? []).length, 5);
-  assert.match(
-    markup,
-    /aria-checked="true" aria-label="Thinking: xhigh effort" tabindex="0"/u,
-  );
+  assert.match(markup, /aria-checked="true" aria-label="Thinking: xhigh effort" tabindex="0"/u);
   assert.match(markup, />XHigh</u);
   assert.match(markup, />Max</u);
   assert.doesNotMatch(markup, />Off</u);

--- a/renderer/components/thinking-control.tsx
+++ b/renderer/components/thinking-control.tsx
@@ -26,76 +26,79 @@ export function ThinkingControl<TLevel extends GenerationThinkingLevel>({
   onChange: (level: TLevel) => void;
 }) {
   return (
-    <div
-      role="radiogroup"
-      aria-label={`${providerLabel} thinking level`}
-      aria-disabled={disabled || undefined}
-      className="flex h-7 shrink-0 items-center rounded-pill bg-control/50 p-0.5"
-    >
-      {levels.map((value, index) => {
-        const selected = value === level;
-        const hidesMinimumThinking = value === "off" && !canDisable;
-        const label = hidesMinimumThinking ? "Hide" : LABELS[value];
-        return (
-          <button
-            key={value}
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            aria-label={
-              hidesMinimumThinking
-                ? "Thinking: hide model thoughts"
-                : `Thinking: ${value === "off" ? "off" : `${value} effort`}`
-            }
-            tabIndex={selected ? 0 : -1}
-            disabled={disabled}
-            title={
-              hidesMinimumThinking
-                ? "Hide model thoughts (this model still uses its minimum thinking level)"
-                : `${providerLabel} thinking: ${value === "off" ? "off" : value}`
-            }
-            onClick={() => {
-              if (!selected) onChange(value);
-            }}
-            onKeyDown={(event) => {
-              let nextIndex: number | undefined;
-              switch (event.key) {
-                case "ArrowRight":
-                case "ArrowDown":
-                  nextIndex = (index + 1) % levels.length;
-                  break;
-                case "ArrowLeft":
-                case "ArrowUp":
-                  nextIndex = (index - 1 + levels.length) % levels.length;
-                  break;
-                case "Home":
-                  nextIndex = 0;
-                  break;
-                case "End":
-                  nextIndex = levels.length - 1;
-                  break;
+    <div className="group/thinking relative h-8 w-18 shrink-0">
+      <div
+        role="radiogroup"
+        aria-label={`${providerLabel} thinking level`}
+        aria-disabled={disabled || undefined}
+        className="absolute bottom-0 right-0 z-20 flex min-w-18 flex-col items-stretch overflow-hidden rounded-[16px] bg-transparent p-0.5 transition-[background-color,box-shadow] duration-150 ease-out group-hover/thinking:bg-control/80 group-hover/thinking:shadow-control-hover group-focus-within/thinking:bg-control/80 group-focus-within/thinking:shadow-control-hover"
+      >
+        {levels.map((value, index) => {
+          const selected = value === level;
+          const hidesMinimumThinking = value === "off" && !canDisable;
+          const label = hidesMinimumThinking ? "Hide" : LABELS[value];
+          return (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={
+                hidesMinimumThinking
+                  ? "Thinking: hide model thoughts"
+                  : `Thinking: ${value === "off" ? "off" : `${value} effort`}`
               }
-              if (nextIndex === undefined) return;
-              event.preventDefault();
-              const nextLevel = levels[nextIndex];
-              if (nextLevel !== level) onChange(nextLevel);
-              const radios =
-                event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>(
-                  '[role="radio"]',
-                );
-              radios?.[nextIndex]?.focus();
-            }}
-            className={cn(
-              "h-6 rounded-pill px-1.5 text-small outline-none transition-[background-color,box-shadow,color,opacity] duration-150 ease-out focus-visible:outline-none disabled:pointer-events-none disabled:opacity-45",
-              selected
-                ? "bg-popover text-primary shadow-control focus-visible:bg-popover"
-                : "text-tertiary hover:bg-list-hover hover:text-secondary active:bg-list-selection focus-visible:bg-list-selection",
-            )}
-          >
-            {label}
-          </button>
-        );
-      })}
+              tabIndex={selected ? 0 : -1}
+              aria-disabled={disabled || undefined}
+              title={
+                hidesMinimumThinking
+                  ? "Hide model thoughts (this model still uses its minimum thinking level)"
+                  : `${providerLabel} thinking: ${value === "off" ? "off" : value}`
+              }
+              onClick={() => {
+                if (!disabled && !selected) onChange(value);
+              }}
+              onKeyDown={(event) => {
+                if (disabled) return;
+                let nextIndex: number | undefined;
+                switch (event.key) {
+                  case "ArrowRight":
+                  case "ArrowDown":
+                    nextIndex = (index + 1) % levels.length;
+                    break;
+                  case "ArrowLeft":
+                  case "ArrowUp":
+                    nextIndex = (index - 1 + levels.length) % levels.length;
+                    break;
+                  case "Home":
+                    nextIndex = 0;
+                    break;
+                  case "End":
+                    nextIndex = levels.length - 1;
+                    break;
+                }
+                if (nextIndex === undefined) return;
+                event.preventDefault();
+                const nextLevel = levels[nextIndex];
+                if (nextLevel !== level) onChange(nextLevel);
+                const radios =
+                  event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>(
+                    '[role="radio"]',
+                  );
+                radios?.[nextIndex]?.focus();
+              }}
+              className={cn(
+                "flex h-7 w-full items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap rounded-pill px-3 text-regular outline-none transition-[max-height,background-color,box-shadow,color,opacity] duration-150 ease-out focus-visible:outline-none aria-disabled:cursor-default",
+                selected
+                  ? "max-h-7 bg-transparent text-primary group-hover/thinking:bg-popover group-hover/thinking:shadow-control group-focus-within/thinking:bg-popover group-focus-within/thinking:shadow-control"
+                  : "pointer-events-none max-h-0 text-tertiary opacity-0 group-hover/thinking:pointer-events-auto group-hover/thinking:max-h-7 group-hover/thinking:opacity-100 group-focus-within/thinking:pointer-events-auto group-focus-within/thinking:max-h-7 group-focus-within/thinking:opacity-100 hover:bg-list-hover hover:text-secondary active:bg-list-selection focus-visible:bg-list-selection",
+              )}
+            >
+              <span>{label}</span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/renderer/components/ui.tsx
+++ b/renderer/components/ui.tsx
@@ -1459,10 +1459,19 @@ export const Command = React.forwardRef<
 });
 export const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(function CommandInput({ className, ...props }, ref) {
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+    containerClassName?: string;
+    showSeparator?: boolean;
+  }
+>(function CommandInput({ className, containerClassName, showSeparator = true, ...props }, ref) {
   return (
-    <div className="flex h-9 items-center gap-2 border-b border-separator px-3">
+    <div
+      className={cn(
+        "flex h-9 items-center gap-2 px-3",
+        showSeparator && "border-b border-separator",
+        containerClassName,
+      )}
+    >
       <Search className="size-4 shrink-0 text-tertiary" />
       <CommandPrimitive.Input
         ref={ref}

--- a/renderer/lib/command-palette-contract.test.ts
+++ b/renderer/lib/command-palette-contract.test.ts
@@ -2,10 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-const source = readFileSync(
-  new URL("../components/command-palette.tsx", import.meta.url),
-  "utf8",
-);
+const source = readFileSync(new URL("../components/command-palette.tsx", import.meta.url), "utf8");
 
 function between(start: string, end: string): string {
   const startIndex = source.indexOf(start);
@@ -38,18 +35,22 @@ test("delayed appearance persistence cannot close a later palette session", () =
 
 test("current model and appearance values are exposed to assistive technology", () => {
   assert.match(source, /aria-current=\{selected \? "true" : undefined\}/u);
-  assert.match(
-    source,
-    /aria-current=\{appearanceMode === item\.mode \? "true" : undefined\}/u,
-  );
+  assert.match(source, /aria-current=\{appearanceMode === item\.mode \? "true" : undefined\}/u);
   assert.ok((source.match(/<span className="sr-only">Current<\/span>/gu)?.length ?? 0) >= 2);
 });
 
 test("dynamic command registration invalidates palette availability", () => {
   const commandSystem = readFileSync(new URL("./command-system.tsx", import.meta.url), "utf8");
   assert.match(commandSystem, /const \[handlerRevision, setHandlerRevision\]/u);
-  assert.ok(
-    (commandSystem.match(/setHandlerRevision\(\(.*?\) => .*? \+ 1\)/gu)?.length ?? 0) >= 2,
-  );
+  assert.ok((commandSystem.match(/setHandlerRevision\(\(.*?\) => .*? \+ 1\)/gu)?.length ?? 0) >= 2);
   assert.match(commandSystem, /handlerRevision,/u);
+});
+
+test("command palette uses spacing instead of separator rules", () => {
+  assert.doesNotMatch(source, /CommandSeparator/u);
+  assert.doesNotMatch(source, /border-b border-separator/u);
+  assert.doesNotMatch(source, /border-t border-separator/u);
+  assert.match(source, /showSeparator=\{false\}/u);
+  assert.match(source, /cmdk-item\]\[data-selected=true\].*bg-control/u);
+  assert.doesNotMatch(source, /↑↓ Navigate|↩ Run|Local app actions/u);
 });

--- a/tests/e2e/chat-shell-interactions.spec.ts
+++ b/tests/e2e/chat-shell-interactions.spec.ts
@@ -40,7 +40,7 @@ test("chat shell keeps local interactions isolated and keyboard-accessible", asy
   await composer.fill("/");
   const slashCommands = page.getByRole("listbox", { name: "Slash commands" });
   await expect(slashCommands).toBeVisible();
-  await expect(slashCommands.getByRole("option").filter({ hasText: "/model" })).toBeVisible();
+  await expect(slashCommands.getByRole("option", { name: /^Choose model/u })).toBeVisible();
   await composer.press("Escape");
   await expect(slashCommands).toBeHidden();
   await expect(composer).toHaveValue("/");
@@ -82,12 +82,15 @@ test("chat shell keeps local interactions isolated and keyboard-accessible", asy
     name: /^Workspace access: Ask first/u,
   });
   await permission.click();
-  const noAccess = page.getByRole("menuitemcheckbox", { name: "No access" });
+  const accessOptions = page.getByRole("radiogroup", { name: "Workspace access" });
+  const askFirst = accessOptions.getByRole("radio", { name: /^Workspace access: Ask first/u });
+  const noAccess = accessOptions.getByRole("radio", { name: /^Workspace access: No access/u });
+  await expect(askFirst).toHaveAttribute("aria-checked", "true");
   await expect(noAccess).toHaveAttribute("aria-checked", "false");
   await noAccess.click();
+  await expect(noAccess).toHaveAttribute("aria-checked", "true");
   await expect(page.getByRole("button", { name: /^Workspace access: No access/u })).toBeVisible();
-  await page.getByRole("button", { name: /^Workspace access: No access/u }).click();
-  await page.getByRole("menuitemcheckbox", { name: "Ask first" }).click();
+  await askFirst.click();
   await expect(permission).toBeVisible();
 
   await composer.fill("Draft and attachment stay with this chat only.");
@@ -130,4 +133,48 @@ test("chat shell keeps local interactions isolated and keyboard-accessible", asy
   await expect(palette.getByText("Toggle sidebar", { exact: true })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(palette).toBeHidden();
+});
+
+test.describe("with a workspace", () => {
+  test.use({ workspaceSeed: true });
+
+  test("workspace access arrows move focus and explicit keys commit", async ({ aiden }) => {
+    const { page } = aiden;
+    await finishLmStudioOnboarding(page);
+
+    const permission = page.getByRole("button", { name: /^Workspace access: Full access/u });
+    await permission.click();
+    const accessOptions = page.getByRole("radiogroup", { name: "Workspace access" });
+    const fullAccess = accessOptions.getByRole("radio", {
+      name: /^Workspace access: Full access/u,
+    });
+    const askFirst = accessOptions.getByRole("radio", { name: /^Workspace access: Ask first/u });
+    const noAccess = accessOptions.getByRole("radio", { name: /^Workspace access: No access/u });
+    await fullAccess.focus();
+    await expect(fullAccess).toBeFocused();
+
+    await fullAccess.press("ArrowDown");
+    await expect(askFirst).toBeFocused();
+    await expect(fullAccess).toHaveAttribute("aria-checked", "true");
+    await askFirst.press("Enter");
+    await expect(askFirst).toHaveAttribute("aria-checked", "true");
+
+    await askFirst.press("ArrowUp");
+    await expect(fullAccess).toBeFocused();
+    await expect(page.getByRole("dialog", { name: "Enable Full Access?" })).toHaveCount(0);
+    await expect(askFirst).toHaveAttribute("aria-checked", "true");
+
+    await fullAccess.press("ArrowDown");
+    await askFirst.press("ArrowDown");
+    await expect(noAccess).toBeFocused();
+    await expect(askFirst).toHaveAttribute("aria-checked", "true");
+    await noAccess.press(" ");
+    await expect(noAccess).toHaveAttribute("aria-checked", "true");
+
+    await noAccess.press("ArrowUp");
+    await expect(askFirst).toBeFocused();
+    await expect(noAccess).toHaveAttribute("aria-checked", "true");
+    await askFirst.press("Enter");
+    await expect(askFirst).toHaveAttribute("aria-checked", "true");
+  });
 });


### PR DESCRIPTION
## Summary
- make workspace access and thinking effort compact controls that expand on hover or keyboard focus
- simplify command and slash palette hierarchy with softer selection surfaces and less separator chrome
- refine slash-command labels, model-picker affordance, and shared command input styling
- extend accessibility and UI contract coverage

## Verification
- focused affected renderer tests: 40 passed
- npm run type-check
- npm run lint
- oxfmt check for all changed TypeScript/TSX files
- git diff --check

## Note
- npm run test:command-system currently has one unrelated existing failure in renderer-readiness-core.test.ts because main wraps rendererReadiness.reset() in resetRendererReadiness(); the affected command-palette tests in that suite pass.