### PR TITLE
Fix Generative UI containment in macOS release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install locked dependencies
         run: npm ci
 
+      - name: Install Playwright Chromium for Generative UI containment
+        run: npx playwright install chromium
+
       - name: Assign the main-push version
         id: version
         shell: bash

--- a/scripts/diagnostic-policy.test.mjs
+++ b/scripts/diagnostic-policy.test.mjs
@@ -69,6 +69,13 @@ test("release runs signed packaged diagnostics acceptance before publication", (
   assert.ok(dist >= 0 && packaged > dist && publish > packaged);
 });
 
+test("release installs Chromium before JavaScript containment tests", () => {
+  const release = fs.readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8");
+  const install = release.indexOf("run: npx playwright install chromium");
+  const testSuite = release.indexOf("run: npm test");
+  assert.ok(install >= 0 && testSuite > install);
+});
+
 test("CI uploads only the fixed sanitized receipt with short retention", () => {
   for (const workflow of [".github/workflows/ci.yml", ".github/workflows/release.yml"]) {
     const source = fs.readFileSync(path.join(root, workflow), "utf8");


### PR DESCRIPTION
## Summary

- install Playwright Chromium before the release job runs the Generative UI containment suite
- add a policy test that enforces the install step precedes npm test

## Evidence

The first 0.35 release run reached the containment suite but failed all five browser checks because Chromium was not installed. CI already performs this setup; this aligns the release workflow with it.

## Verification

- diagnostic policy tests: 7/7
- ESLint
- git diff check