### PR TITLE
Release Aiden Agent 0.35.77

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-agent",
-  "version": "0.35.76",
+  "version": "0.35.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-agent",
-      "version": "0.35.76",
+      "version": "0.35.77",
       "hasInstallScript": true,
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-agent",
-  "version": "0.35.76",
+  "version": "0.35.77",
   "private": true,
   "description": "A macOS AI workspace agent for local and hosted models",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump the desktop release version from `0.35.76` to `0.35.77`
- build from `main` commit `76ca87395`, which contains the packaged Tailscale CLI fix from #65
- keep the package manifest and lockfile release metadata aligned

## Validation

- `npm run type-check`
- `npm run test:branding` — 32 TypeScript and 18 Node tests passed
- `npm run release:check-consumers`
- focused Tailscale suite — 32 tests passed, including Finder-style CLI mode and both timeout shapes
- confirmed `v0.35.77` is unused and eligible for publication