### PR TITLE
Release Aiden Agent 0.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-agent",
-  "version": "0.35.77",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-agent",
-      "version": "0.35.77",
+      "version": "0.36.0",
       "hasInstallScript": true,
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-agent",
-  "version": "0.35.77",
+  "version": "0.36.0",
   "private": true,
   "description": "A macOS AI workspace agent for local and hosted models",
   "keywords": [


### PR DESCRIPTION
## Summary

- declare desktop release version 0.36.0
- keep package.json and package-lock.json aligned

## Validation

- npm run test:branding
- full integrated npm test on the merged PR 67 + PR 68 tree
- local release preflight reaches the protected notarization-credential gate; GitHub release environment owns those credentials