### PR TITLE
Release 0.37.0

### DIFF
--- a/.papercuts/troubleshooting.md
+++ b/.papercuts/troubleshooting.md
@@ -188,3 +188,9 @@ CI with `npx playwright install chromium` before the first full local gate.
 The Dropbox origin-level protected-resource endpoint can return 429 while the
 resource-path endpoint advertised by `WWW-Authenticate` succeeds. Verify hosted
 MCP setup through that advertised RFC 9728 URL and the SDK's DCR redirect flow.
+
+## Release preflight environment
+
+`npm run release:preflight` intentionally fails outside the release runner when
+Apple notarization credentials are absent. Treat local consumer/branding tests
+as code gates and the credentialed GitHub release job as the signing gate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiden-agent",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiden-agent",
-      "version": "0.36.1",
+      "version": "0.37.0",
       "hasInstallScript": true,
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.84.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiden-agent",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "private": true,
   "description": "A macOS AI workspace agent for local and hosted models",
   "keywords": [


### PR DESCRIPTION
## Summary

- release unified workspace and chat navigation across clients
- release Pi compaction, journal migration, and durable memory upgrades
- release the official Codex plugin catalog and production subagent recovery fixes
- bump package metadata to 0.37.0

## Validation

- `npm run release:check-consumers`
- `npm run test:branding`
- `npm run release:preflight` reaches the expected local Apple notarization credential boundary; signing/notarization remains the credentialed release-workflow gate
