### PR TITLE
Publish Android APK artifacts only from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,12 +157,11 @@ jobs:
           "emulator"
           "system-images;android-36;google_apis;x86_64"
 
-      - name: Verify Android and assemble debug APK
+      - name: Verify Android
         run: >-
           ./gradlew
           :app:testDebugUnitTest
           :app:lintDebug
-          :app:assembleDebug
           :app:compileDebugAndroidTestKotlin
           --stacktrace
 
@@ -178,10 +177,16 @@ jobs:
           disable-animations: true
           script: ./gradlew :app:connectedDebugAndroidTest --stacktrace
 
+      - name: Assemble installable debug APK
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: ./gradlew :app:assembleDebug --stacktrace
+
       - name: Record APK checksum
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: sha256sum app/build/outputs/apk/debug/app-debug.apk > app/build/outputs/apk/debug/app-debug.apk.sha256
 
       - name: Upload installable debug APK
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: aiden-on-the-go-debug-apk

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The native Aiden On The Go iPhone and iPad client lives in [`ios/`](ios/README.m
 
 ### Mobile distribution
 
-The iPhone and iPad app is distributed through **TestFlight only**. GitHub releases do not publish an IPA; [`ios/README.md`](ios/README.md) documents local development and device validation. Android validation builds remain separate from the macOS release and are uploaded by CI as installable APK artifacts.
+The iPhone and iPad app is distributed through **TestFlight only**. GitHub releases do not publish an IPA; [`ios/README.md`](ios/README.md) documents local development and device validation. Android validation remains separate from the macOS release. Pull requests run the Android verification gates without retaining an installable artifact; relevant merges to `main` publish the debug APK and its checksum.
 
 The development launcher prepares a cached, ad-hoc-signed **Aiden Agent Dev** runtime that can run beside the installed **Aiden Agent** app. Development uses separate Application Support, Chromium session, log, crash, and `~/.aiden-dev` roots; it does not copy production data, register global shortcuts, or check the production update feed by default. Set `AIDEN_DEV_GLOBAL_SHORTCUTS=1` only when a development run intentionally needs the global bindings.
 

--- a/scripts/check-ci-policy.test.mjs
+++ b/scripts/check-ci-policy.test.mjs
@@ -9,6 +9,14 @@ const catalogWorkflowUrl = new URL(
   import.meta.url,
 );
 
+function workflowStep(workflow, name) {
+  const marker = `      - name: ${name}`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `Missing workflow step: ${name}`);
+  const next = workflow.indexOf("\n      - name:", start + marker.length);
+  return workflow.slice(start, next === -1 ? workflow.length : next);
+}
+
 test("Android CI only runs for Android or CI workflow changes", async () => {
   const workflow = await readFile(workflowUrl, "utf8");
 
@@ -20,6 +28,16 @@ test("Android CI only runs for Android or CI workflow changes", async () => {
   assert.match(workflow, /^ {4}needs: changes$/mu);
   assert.match(workflow, /^ {4}if: \$\{\{ needs\.changes\.outputs\.android == 'true' \}\}$/mu);
   assert.match(workflow, /npm run test:model-catalog/u);
+
+  const mainPushOnly =
+    /if: \$\{\{ github\.event_name == 'push' && github\.ref == 'refs\/heads\/main' \}\}/u;
+  assert.doesNotMatch(workflowStep(workflow, "Verify Android"), /:app:assembleDebug/u);
+
+  const assembly = workflowStep(workflow, "Assemble installable debug APK");
+  assert.match(assembly, mainPushOnly);
+  assert.match(assembly, /:app:assembleDebug/u);
+  assert.match(workflowStep(workflow, "Record APK checksum"), mainPushOnly);
+  assert.match(workflowStep(workflow, "Upload installable debug APK"), mainPushOnly);
 });
 
 test("model catalog workflow verifies read-only and publishes with isolated credentials", async () => {


### PR DESCRIPTION
## Summary

- keep Android unit, lint, compilation, and Compose UI validation on relevant pull requests
- assemble, checksum, and upload the installable debug APK only for relevant pushes to `main`
- add CI policy coverage and clarify the artifact behavior in the README

## Validation

- `npm run test:branding` (51 tests passed)
- `npx eslint scripts/check-ci-policy.test.mjs`
- CI workflow YAML parse
- `git diff --check`