### PR TITLE
Fix Model Pad picker overlap and double focus chrome

### DIFF
--- a/renderer/components/composer.test.tsx
+++ b/renderer/components/composer.test.tsx
@@ -253,3 +253,29 @@ test("workspace access keyboard navigation moves focus without changing permissi
   assert.match(composer, /radios\?\.\[nextIndex\]\?\.focus\(\)/u);
   assert.doesNotMatch(composer, /requestPermission\(nextPermission\)/u);
 });
+
+test("model picker details sit beside the menu without overlapping the pad", () => {
+  const modelPicker = source("./model-picker.tsx");
+  const pad = source("./model-picker-pad.tsx");
+  const styles = source("../styles.css");
+
+  assert.match(
+    modelPicker,
+    /className="flex w-max max-w-\[calc\(100vw-1\.5rem\)\] items-start gap-2 overflow-visible bg-transparent p-0 shadow-none"/u,
+  );
+  assert.match(
+    modelPicker,
+    /className="relative w-\[min\(19\.75rem,calc\(100vw-1\.5rem\)\)\] overflow-hidden rounded-popover bg-popover shadow-popover"/u,
+  );
+  assert.match(
+    modelPicker,
+    /className="pointer-events-none w-56 shrink-0 rounded-popover bg-popover p-3 text-primary shadow-popover"/u,
+  );
+  assert.doesNotMatch(modelPicker, /left-\[calc\(100%\+0\.5rem\)\]/u);
+  assert.doesNotMatch(modelPicker, /right: showExternalDetails/u);
+  assert.doesNotMatch(pad, /focus-visible:bg-list-selection/u);
+  assert.match(
+    styles,
+    /\.model-pad:focus-visible\s*\{\s*outline: none !important;\s*box-shadow:\s*inset 0 0 0 2px var\(--focus-ring\)/u,
+  );
+});

--- a/renderer/components/model-picker-pad.tsx
+++ b/renderer/components/model-picker-pad.tsx
@@ -219,7 +219,7 @@ export function ModelPickerPad({
         aria-describedby={helpId}
         aria-activedescendant={active ? modelOptionId(active.value) : undefined}
         data-dragging={dragging ? "true" : "false"}
-        className="model-pad relative aspect-square w-full touch-none overflow-hidden rounded-card outline-none focus-visible:bg-list-selection focus-visible:outline-none "
+        className="model-pad relative aspect-square w-full touch-none overflow-hidden rounded-card outline-none"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}

--- a/renderer/components/model-picker.tsx
+++ b/renderer/components/model-picker.tsx
@@ -257,7 +257,7 @@ function ModelHoverDetails({
   ].filter((row): row is [string, string] => Boolean(row));
 
   return (
-    <aside className="pointer-events-none absolute left-[calc(100%+0.5rem)] top-0 w-56 rounded-popover bg-popover p-3 text-primary shadow-popover">
+    <aside className="pointer-events-none w-56 shrink-0 rounded-popover bg-popover p-3 text-primary shadow-popover">
       <div className="flex min-w-0 items-start gap-2">
         <span className="mt-0.5 shrink-0 text-tertiary">
           <ProviderIcon
@@ -530,13 +530,8 @@ export function ModelPicker({
         side="top"
         align="end"
         sideOffset={8}
-        collisionPadding={{
-          top: 40,
-          right: showExternalDetails && (view === "list" || hasPadModels) ? 244 : 12,
-          bottom: 12,
-          left: 12,
-        }}
-        className="relative w-[min(19.75rem,calc(100vw-1.5rem))] overflow-visible p-0"
+        collisionPadding={{ top: 40, right: 12, bottom: 12, left: 12 }}
+        className="flex w-max max-w-[calc(100vw-1.5rem)] items-start gap-2 overflow-visible bg-transparent p-0 shadow-none"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           requestAnimationFrame(() => {
@@ -551,6 +546,7 @@ export function ModelPicker({
           });
         }}
       >
+        <div className="relative w-[min(19.75rem,calc(100vw-1.5rem))] overflow-hidden rounded-popover bg-popover shadow-popover">
         <div className="p-1.5 pb-0">
           <div
             className="grid grid-cols-2 rounded-control bg-control/60 p-0.5"
@@ -707,9 +703,7 @@ export function ModelPicker({
           </section>
         )}
 
-        {showExternalDetails && (view === "list" || hasPadModels) ? (
-          <ModelHoverDetails model={activePosition} metadataLoading={metadataLoading} />
-        ) : activeAttribution ? (
+        {!(showExternalDetails && (view === "list" || hasPadModels)) && activeAttribution ? (
           <div className="border-t border-separator px-3 py-1.5 text-mini leading-4">
             <a
               href={activeAttribution.url}
@@ -720,6 +714,10 @@ export function ModelPicker({
               {activeAttribution.label}
             </a>
           </div>
+        ) : null}
+        </div>
+        {showExternalDetails && (view === "list" || hasPadModels) ? (
+          <ModelHoverDetails model={activePosition} metadataLoading={metadataLoading} />
         ) : null}
       </PopoverContent>
     </Popover>

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -615,6 +615,16 @@ textarea {
     inset 0 1px 0 rgb(255 255 255 / 7%);
 }
 
+/* The pad is a large listbox. An offset outline sits in the picker padding and
+   reads as a second chrome ring around the canvas; keep keyboard focus inside. */
+.model-pad:focus-visible {
+  outline: none !important;
+  box-shadow:
+    inset 0 0 0 2px var(--focus-ring),
+    inset 0 0 0 0.5px var(--border-separator),
+    inset 0 1px 0 rgb(255 255 255 / 7%);
+}
+
 .model-pad::after {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening the composer model picker on Pad view showed two layout glitches:

- The model-details card was absolutely positioned outside the menu box, so it could sit on top of the pad instead of beside it.
- The pad is a focused `listbox`, so the global `outline-offset: 2px` ring landed in the popover padding and looked like a second chrome border around the canvas.

## Change

- Lay the picker menu and the details card out as siblings in the popover (`flex` + gap), so collision detection includes both and the details card no longer overlays the pad.
- Keep keyboard focus visible with an inset ring on `.model-pad:focus-visible` instead of the offset outline, and drop the full-canvas `list-selection` fill on focus.

## Tests

- Extended `renderer/components/composer.test.tsx` to lock the in-flow details layout and inset pad focus contract.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff219910-3f40-4da2-bd12-ef23ba33fdb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff219910-3f40-4da2-bd12-ef23ba33fdb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

