### PR TITLE
Make composer access and thinking menus opaque

### DIFF
--- a/.papercuts/troubleshooting.md
+++ b/.papercuts/troubleshooting.md
@@ -379,3 +379,7 @@ owns; reopen the terminal before judging the final live state.
 
 - Zsh does not split scalar loop values by default; use explicit delimiters in pairwise merge probes so branch names are not accidentally concatenated.
 - Standalone green PRs still conflicted in shared settings, test registries, and UI fixtures. Assemble the exact combined stack and retain every feature's test registration before merging to main.
+
+- 2026-09-09: Fresh selector-fix worktree lacks `.memory/` and dependencies; use current design docs and install locked dependencies before validation.
+- 2026-09-09: `npm ci` omitted Electron.app in this worktree; ran `node node_modules/electron/install.js` before Electron tests.
+- 2026-09-09: Playwright JSX transform serializes imported TSX into component objects; render the thinking CSS fixture in a tsx subprocess before mounting its markup in Electron.

--- a/renderer/components/composer.test.tsx
+++ b/renderer/components/composer.test.tsx
@@ -57,7 +57,8 @@ test("composer context controls stay compact without exposing provider copy", ()
   assert.match(composer, /aria-controls=\{permissionOptionsId\}/u);
   assert.doesNotMatch(composer, /aria-haspopup=\{true\}/u);
   assert.match(composer, /group-data-\[open=true\]\/access:visible/u);
-  assert.match(composer, /bg-control\/80/u);
+  assert.match(composer, /rounded-dialog bg-popover p-1/u);
+  assert.doesNotMatch(composer, /bg-control\/80/u);
   assert.match(composer, /selected\s*\? "bg-popover shadow-control"/u);
   assert.doesNotMatch(composer, /group-hover\/access:max-h/u);
   assert.match(composer, /aria-disabled=\{disabled \|\| undefined\}/u);

--- a/renderer/components/composer.tsx
+++ b/renderer/components/composer.tsx
@@ -1845,7 +1845,7 @@ export function Composer({
                       Boolean(workspaceChangeBlockedReason) ||
                       undefined
                     }
-                    className="invisible pointer-events-none absolute bottom-full left-0 z-20 flex min-w-34 translate-y-1 flex-col items-stretch overflow-hidden rounded-dialog bg-control/80 p-1 opacity-0 shadow-control-hover transition-[opacity,transform,visibility] duration-100 ease-out group-data-[open=true]/access:visible group-data-[open=true]/access:pointer-events-auto group-data-[open=true]/access:translate-y-0 group-data-[open=true]/access:opacity-100"
+                    className="invisible pointer-events-none absolute bottom-full left-0 z-20 flex min-w-34 translate-y-1 flex-col items-stretch overflow-hidden rounded-dialog bg-popover p-1 opacity-0 shadow-control-hover transition-[opacity,transform,visibility] duration-100 ease-out group-data-[open=true]/access:visible group-data-[open=true]/access:pointer-events-auto group-data-[open=true]/access:translate-y-0 group-data-[open=true]/access:opacity-100"
                   >
                     {PERMISSION_ORDER.map((value, index) => {
                       const meta = PERMISSION_META[value];

--- a/renderer/components/thinking-control.test.tsx
+++ b/renderer/components/thinking-control.test.tsx
@@ -26,7 +26,8 @@ test("renders an accessible four-step Gemini thinking control", () => {
   assert.match(markup, /pointer-events-none max-h-0/u);
   assert.match(markup, /group-hover\/thinking:max-h-7/u);
   assert.match(markup, /group-focus-within\/thinking:max-h-7/u);
-  assert.match(markup, /group-hover\/thinking:bg-control\/80/u);
+  assert.doesNotMatch(markup, /bg-control\/80/u);
+  assert.match(markup, /group-focus-within\/thinking:bg-popover/u);
   assert.match(markup, /group-hover\/thinking:bg-popover/u);
   assert.doesNotMatch(markup, /disabled:opacity-45/u);
 });

--- a/renderer/components/thinking-control.tsx
+++ b/renderer/components/thinking-control.tsx
@@ -31,7 +31,7 @@ export function ThinkingControl<TLevel extends GenerationThinkingLevel>({
         role="radiogroup"
         aria-label={`${providerLabel} thinking level`}
         aria-disabled={disabled || undefined}
-        className="absolute bottom-0 right-0 z-20 flex min-w-18 flex-col items-stretch overflow-hidden rounded-dialog bg-transparent p-0.5 transition-[background-color,box-shadow] duration-150 ease-out group-hover/thinking:bg-control/80 group-hover/thinking:shadow-control-hover group-focus-within/thinking:bg-control/80 group-focus-within/thinking:shadow-control-hover"
+        className="absolute bottom-0 right-0 z-20 flex min-w-18 flex-col items-stretch overflow-hidden rounded-dialog bg-transparent p-0.5 transition-[background-color,box-shadow] duration-150 ease-out group-hover/thinking:bg-popover group-hover/thinking:shadow-control-hover group-focus-within/thinking:bg-popover group-focus-within/thinking:shadow-control-hover"
       >
         {levels.map((value, index) => {
           const selected = value === level;

--- a/tests/e2e/chat-shell-interactions.spec.ts
+++ b/tests/e2e/chat-shell-interactions.spec.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+import { getPresetVariant, resolveThemeTokens } from "../../renderer/shared/appearance";
 import { expect, expectSquircleButtons, finishLmStudioOnboarding, test } from "./fixtures";
 
 const PASTED_IMAGE_NAME = "Pasted image.png";
@@ -485,4 +487,62 @@ test("compaction commands keep cancellation available for every engine", async (
     ).compactionCommandTest.finishExport();
   });
   await expect(composer).toBeEditable();
+});
+
+
+test("composer selector menus use opaque theme surfaces on hover and keyboard focus", async ({ aiden }) => {
+  const { page } = aiden;
+  await finishLmStudioOnboarding(page);
+  // The deterministic local model has no effort selector. Mount the real component's
+  // markup to exercise its hover/focus CSS against the shipped renderer stylesheet.
+  // Render outside Playwright, whose JSX transform serializes component objects.
+  const thinkingMarkup = execFileSync(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
+    import { createElement } from "react";
+    import { renderToStaticMarkup } from "react-dom/server";
+    import { ThinkingControl } from "./renderer/components/thinking-control.tsx";
+    process.stdout.write(renderToStaticMarkup(createElement(ThinkingControl, {
+      level: "medium", levels: ["off", "low", "medium", "high"], onChange: () => undefined,
+    })));
+  `], { encoding: "utf8" });
+  await page.evaluate((markup) => {
+    const host = document.createElement("div");
+    host.id = "thinking-surface-fixture";
+    host.style.cssText = "position:fixed;right:40px;bottom:180px;z-index:100";
+    host.innerHTML = markup;
+    document.body.append(host);
+  }, thinkingMarkup);
+  const permission = page.getByRole("button", { name: /^Workspace access:/u });
+  const access = page.getByRole("radiogroup", { name: "Workspace access", exact: true });
+  const thinking = page.getByRole("radiogroup", { name: "Gemini thinking level" });
+  const selectedThinking = thinking.getByRole("radio", { name: "Thinking: medium effort" });
+  for (const scheme of ["light", "dark"] as const) {
+    const tokens = resolveThemeTokens(getPresetVariant("aiden", scheme), scheme);
+    const expected = await page.evaluate((themeTokens) => {
+      for (const [name, value] of Object.entries(themeTokens)) document.documentElement.style.setProperty(name, value);
+      const probe = document.createElement("div");
+      probe.style.backgroundColor = "var(--surface-popover)";
+      document.body.append(probe);
+      const color = getComputedStyle(probe).backgroundColor;
+      probe.remove();
+      return color;
+    }, tokens);
+    expect(expected).toMatch(/^rgb\(/u);
+    await permission.hover();
+    await expect(access).toHaveCSS("background-color", expected);
+    await expect(access).toHaveCSS("opacity", "1");
+    await permission.press("Escape");
+    await page.mouse.move(0, 0);
+    await permission.focus();
+    await expect(access).toHaveCSS("background-color", expected);
+    await expect(access).toHaveCSS("opacity", "1");
+    await permission.press("Escape");
+    await selectedThinking.hover();
+    await expect(thinking).toHaveCSS("background-color", expected);
+    await selectedThinking.focus();
+    await page.mouse.move(0, 0);
+    await expect(thinking).toHaveCSS("background-color", expected);
+    await expect(selectedThinking).toHaveCSS("outline-style", "solid");
+    await page.locator("textarea").focus();
+    await expect(thinking).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+  }
 });


### PR DESCRIPTION
Opening the composer's access or thinking selector lets underlying chat text show through its translucent control fill. Use the existing opaque popover surface for the access menu and expanded thinking menu, preserving collapsed thinking styling, selection shadows, and keyboard behavior.

Validation: 15 focused unit tests, build, focused lint, Electron test type-check, existing access keyboard Electron test, and a new rendered Electron regression covering light/dark themes and hover/focus states. Independent subagent review found no outstanding issues.
