### PR TITLE
Exclude legacy Gemini families from Google chat catalogs

### DIFF
--- a/.papercuts/troubleshooting.md
+++ b/.papercuts/troubleshooting.md
@@ -379,3 +379,10 @@ owns; reopen the terminal before judging the final live state.
 
 - Zsh does not split scalar loop values by default; use explicit delimiters in pairwise merge probes so branch names are not accidentally concatenated.
 - Standalone green PRs still conflicted in shared settings, test registries, and UI fixtures. Assemble the exact combined stack and retain every feature's test registration before merging to main.
+
+## 2026-09-10 — Google catalog PR validation
+
+The main checkout's shared node_modules matched Pi's pinned version but lacked
+postcss-value-parser and @xterm/addon-web-links required by this worktree. The
+resulting type errors disappeared after replacing the temporary dependency
+symlink with this checkout's own npm ci. Full type-check and lint then passed.

--- a/docs/plans/dynamic-model-catalog-plan.md
+++ b/docs/plans/dynamic-model-catalog-plan.md
@@ -13,6 +13,31 @@ Aiden users should get newly published hosted models (for example Opus 5) **with
 
 ## Implementation record (2026-08-22)
 
+### Google legacy catalog override (2026-09-10)
+
+Aiden excludes `gemini-2.5-*`, `gemini-2.0-*`, and `gemini-1.5-*` from the
+Google chat inventory, including dated variants. The policy applies after merging
+the bundled and remote catalogs, so offline hydration and refresh cannot restore
+them. Native connection discovery applies the same policy. Pi model lookup and
+the Mac/iOS/Android catalog projections use the filtered inventory; stale remote
+defaults fall back to an available model and explicit removed selections fail.
+Historical preset helpers retain their original model lists and metadata for
+exact configuration-migration matching. Custom connections and voice inventory
+are outside this Google chat override.
+
+Research: Google's [Interactions overview](https://ai.google.dev/gemini-api/docs/interactions-overview)
+still lists Gemini 2.5 and says `generateContent` remains supported. This exclusion
+is Aiden's requested product policy, not a claim that every Google endpoint has
+retired 2.5. The existing Pi `google-generative-ai` transport stays in place;
+adopting Interactions would separately require streaming/tool/caching and storage
+semantics work (its default is `store=true`).
+
+Focused catalog, discovery, migration, remote projection, and selection tests
+cover the override. Both native pickers render the host-provided model list;
+there is no wire-schema or native UI change.
+
+### Original implementation
+
 - Option A is accepted: Aiden reads full executable model records only from the fixed
   `https://pi.dev` provider endpoint. Requests carry a static versioned Aiden/Pi
   User-Agent and never provider credentials, chat content, install IDs, or models.dev data.

--- a/main/services/aiden-remote-models.test.ts
+++ b/main/services/aiden-remote-models.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { AidenRemoteModelService } from "./aiden-remote-models.js";
 import type { Provider } from "./types.js";
+import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import { withPiRemoteCatalog } from "./pi-remote-catalog.js";
 
 function provider(overrides: Partial<Provider> = {}): Provider {
   return {
@@ -26,6 +28,22 @@ function provider(overrides: Partial<Provider> = {}): Provider {
     ...overrides,
   };
 }
+
+test("mobile catalogs omit legacy Google models and recover stale defaults", async () => {
+  const google = builtinProviders().find((entry) => entry.id === "google");
+  assert.ok(google);
+  const models = withPiRemoteCatalog(google).getModels().map((model) => model.id);
+  const service = new AidenRemoteModelService({
+    listProviders: async () => [provider({ id: "google", models, modelMetadata: {} })],
+    getSettings: async () => ({ lastProviderId: "google", lastModel: "gemini-2.5-flash" }),
+  });
+  const catalog = await service.list();
+  assert.ok(catalog.providers[0]?.models.length);
+  assert.ok(catalog.providers[0]?.models.every((model) => !/^gemini-(?:2\.5|2\.0|1\.5)(?:-|$)/u.test(model.id)));
+  assert.ok(catalog.defaults.modelId && models.includes(catalog.defaults.modelId));
+  await assert.rejects(service.resolve("google", "gemini-2.5-flash"),
+    (error: unknown) => (error as { code?: string }).code === "invalid_request");
+});
 
 test("model projection includes only configured chat models and no connection secrets", async () => {
   const service = new AidenRemoteModelService({

--- a/main/services/google-provider.ts
+++ b/main/services/google-provider.ts
@@ -8,6 +8,7 @@ import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import {
   GOOGLE_PROVIDER_ID,
   LEGACY_GEMINI_PROVIDER_ID,
+  isSelectableGoogleCatalogModel,
   migrateLegacyGoogleProviderId,
 } from "../../renderer/shared/google-provider.js";
 import {
@@ -51,7 +52,8 @@ function googleModelMetadata(model: Model<Api>): ProviderModelMetadata {
 }
 
 export function googleProviderModels(): readonly Model<Api>[] {
-  return builtinGoogleModels;
+  // Keep the historical preset helpers intact for exact config migration matching.
+  return builtinGoogleModels.filter((model) => isSelectableGoogleCatalogModel(model.id));
 }
 
 export function googleProviderModelIds(): string[] {

--- a/main/services/models.test.ts
+++ b/main/services/models.test.ts
@@ -69,9 +69,13 @@ test("Google discovery validates the native endpoint and returns only Pi-support
       JSON.stringify({
         models: [
           {
-            name: "models/gemini-2.5-pro",
+            name: "models/gemini-3.5-flash",
             supportedGenerationMethods: ["generateContent"],
           },
+          ...["gemini-2.5-pro", "gemini-2.0-flash", "gemini-1.5-pro"].map((id) => ({
+            name: `models/${id}`,
+            supportedGenerationMethods: ["generateContent"],
+          })),
         ],
       }),
       { status: 200 },
@@ -79,10 +83,10 @@ test("Google discovery validates the native endpoint and returns only Pi-support
   }) as typeof fetch;
 
   const result = await testConnection(canonicalGoogleProvider(), "google-key");
-  assert.deepEqual(result.models, ["gemini-2.5-pro"]);
+  assert.deepEqual(result.models, ["gemini-3.5-flash"]);
   assert.equal(result.modelCount, 1);
-  assert.equal(result.modelMetadata["gemini-2.5-pro"]?.reasoning, true);
-  assert.equal(result.modelMetadata["gemini-2.5-pro"]?.vision, true);
+  assert.equal(result.modelMetadata["gemini-3.5-flash"]?.reasoning, true);
+  assert.equal(result.modelMetadata["gemini-3.5-flash"]?.vision, true);
   assert.equal(requests.length, 2);
 });
 

--- a/main/services/pi-remote-catalog.test.ts
+++ b/main/services/pi-remote-catalog.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   InMemoryCredentialStore,
+  createModels,
   type Api,
   type Credential,
   type CredentialStore,
@@ -35,6 +36,58 @@ import {
   withProviderStreamOverrides,
 } from "./pi-provider-compatibility.js";
 import { piModelMetadataFor } from "./pi-model-metadata.js";
+import { googleProviderModels } from "./google-provider.js";
+import { isSelectableGoogleCatalogModel } from "../../renderer/shared/google-provider.js";
+
+test("Google catalog policy excludes legacy families without excluding current models", () => {
+  for (const id of [
+    "gemini-2.5", "gemini-2.5-pro", "gemini-2.5-flash-lite",
+    "gemini-2.5-computer-use-preview-10-2025", "gemini-2.0-flash-001",
+    "gemini-1.5-pro-latest", "models/gemini-2.5-flash",
+  ]) assert.equal(isSelectableGoogleCatalogModel(id), false, id);
+  for (const id of ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemma-4-31b-it", "gemini-25-flash"])
+    assert.equal(isSelectableGoogleCatalogModel(id), true, id);
+  assert.ok(googleProviderModels().length > 0);
+  assert.ok(googleProviderModels().every((model) => isSelectableGoogleCatalogModel(model.id)));
+});
+
+test("Google legacy models stay excluded across bundled, cached, and refreshed catalogs", async () => {
+  const google = builtinProviders().find((provider) => provider.id === "google");
+  assert.ok(google);
+  const current = google.getModels().find((model) => model.id === "gemini-3.5-flash");
+  assert.ok(current);
+  const legacy = ["gemini-2.5-flash", "gemini-2.0-flash", "gemini-1.5-pro"].map(
+    (id) => ({ ...current, id, name: id }),
+  );
+  const baseline = { ...google, getModels: () => [current, ...legacy] };
+  const checkedAt = Date.parse("2026-09-10T16:01:00Z");
+  const store = memoryProviderStore({
+    models: legacy,
+    checkedAt,
+    lastModified: Date.parse("2026-09-10T16:00:00Z"),
+  } as ModelsStoreEntry);
+  const provider = withPiRemoteCatalog(baseline, {
+    now: () => checkedAt,
+    fetchImpl: async () => Response.json([current, ...legacy], {
+      headers: { "last-modified": "Thu, 10 Sep 2026 16:00:00 GMT" },
+    }),
+  });
+  const models = createModels();
+  models.setProvider(provider);
+  const assertCatalog = () => {
+    assert.deepEqual(provider.getModels().map((model) => model.id), [current.id]);
+    assert.ok(models.getModel("google", current.id));
+    for (const model of legacy) assert.equal(models.getModel("google", model.id), undefined);
+  };
+  assertCatalog();
+  await refreshProvider(provider, store, { allowNetwork: false });
+  assertCatalog();
+  await refreshProvider(provider, store, { force: true });
+  assertCatalog();
+
+  const otherProvider = withPiRemoteCatalog({ ...baseline, id: "custom:google" });
+  assert.deepEqual(otherProvider.getModels().map((model) => model.id), [current, ...legacy].map((model) => model.id));
+});
 
 function opencodeGoProvider() {
   const provider = builtinProviders().find((entry) => entry.id === "opencode-go");

--- a/main/services/pi-remote-catalog.ts
+++ b/main/services/pi-remote-catalog.ts
@@ -1,4 +1,5 @@
 import type { Api, Model, ModelsStoreEntry, Provider } from "@earendil-works/pi-ai";
+import { GOOGLE_PROVIDER_ID, isSelectableGoogleCatalogModel } from "../../renderer/shared/google-provider.js";
 
 const DEFAULT_CATALOG_BASE_URL = "https://pi.dev";
 const MAX_CATALOG_BYTES = 5 * 1024 * 1024;
@@ -318,7 +319,9 @@ export function withPiRemoteCatalog(provider: Provider, options: PiRemoteCatalog
 
   const wrapped: Provider = {
     ...provider,
-    getModels: () => mergeModels(baseline, dynamicModels),
+    getModels: () => mergeModels(baseline, dynamicModels).filter(
+      (model) => provider.id !== GOOGLE_PROVIDER_ID || isSelectableGoogleCatalogModel(model.id),
+    ),
     refreshModels: async (context) => {
       const stored = context.stored as PersistedRemoteCatalog | undefined;
       const restored = restoredCatalog(stored);

--- a/renderer/shared/google-provider.ts
+++ b/renderer/shared/google-provider.ts
@@ -3,6 +3,13 @@ export const LEGACY_GEMINI_PROVIDER_ID = "gemini";
 export const MOONSHOT_AI_PROVIDER_ID = "moonshotai";
 export const LEGACY_MOONSHOT_PROVIDER_ID = "moonshot";
 
+/** Aiden's Google chat catalog excludes legacy families, including dated variants. */
+export function isSelectableGoogleCatalogModel(modelId: string): boolean {
+  return !/^gemini-(?:2\.5|2\.0|1\.5)(?:-|$)/iu.test(
+    modelId.replace(/^models\//iu, ""),
+  );
+}
+
 /** Preserve legacy voice-mode ids while remapping Pi chat-provider ownership. */
 export function migrateLegacyPiProviderId(providerId: string | undefined): string | undefined {
   if (providerId === LEGACY_GEMINI_PROVIDER_ID) return GOOGLE_PROVIDER_ID;


### PR DESCRIPTION
Google's selectable chat catalog included Gemini 2.5, 2.0, and 1.5 models that the user no longer wants offered. Apply an Aiden catalog exclusion after merging Pi's bundled and remote entries, and during native discovery, so cached overlays and refreshes cannot restore those families or dated variants.

The override is scoped to Google chat. Current Gemini models, custom connections, voice inventory, and historical preset matching remain unchanged. Google still documents Gemini 2.5 under Interactions; this is Aiden product policy, not a claim of universal upstream retirement.

Validation: focused catalog/discovery/migration/selection tests and changed-file ESLint passed. Regression coverage exercises bundled entries, offline hydration, forced refresh, runtime lookup, and provider scoping. CI will run the full repository checks.

Stack: base PR; the follow-up adds mobile catalog regression coverage and implementation documentation. Each file is committed separately.

Follow-up: #108 (based on this branch).

Execution behavior: this intentionally removes the models from Pi lookup as well as the picker. Existing chats, schedules, and bot bindings pinned to a removed model must be explicitly reconfigured; generation admission uses the existing unavailable-model recovery error. We do not silently rewrite a task's chosen model. Fresh/default remote selections recover to an available entry (covered by #108).

Provider scope: only the native Google Gemini API provider (`google`) is affected. The separate Google Vertex provider, gateways, and custom endpoints retain their own catalogs. Historical preset ID/metadata/default helpers remain unchanged because exact legacy configuration matching depends on them.
