### PR TITLE
Verify Google catalog exclusions reach mobile clients

### DIFF
--- a/.papercuts/troubleshooting.md
+++ b/.papercuts/troubleshooting.md
@@ -379,3 +379,10 @@ owns; reopen the terminal before judging the final live state.
 
 - Zsh does not split scalar loop values by default; use explicit delimiters in pairwise merge probes so branch names are not accidentally concatenated.
 - Standalone green PRs still conflicted in shared settings, test registries, and UI fixtures. Assemble the exact combined stack and retain every feature's test registration before merging to main.
+
+## 2026-09-10 — Google catalog PR validation
+
+The main checkout's shared node_modules matched Pi's pinned version but lacked
+postcss-value-parser and @xterm/addon-web-links required by this worktree. The
+resulting type errors disappeared after replacing the temporary dependency
+symlink with this checkout's own npm ci. Full type-check and lint then passed.

--- a/docs/plans/dynamic-model-catalog-plan.md
+++ b/docs/plans/dynamic-model-catalog-plan.md
@@ -13,6 +13,31 @@ Aiden users should get newly published hosted models (for example Opus 5) **with
 
 ## Implementation record (2026-08-22)
 
+### Google legacy catalog override (2026-09-10)
+
+Aiden excludes `gemini-2.5-*`, `gemini-2.0-*`, and `gemini-1.5-*` from the
+Google chat inventory, including dated variants. The policy applies after merging
+the bundled and remote catalogs, so offline hydration and refresh cannot restore
+them. Native connection discovery applies the same policy. Pi model lookup and
+the Mac/iOS/Android catalog projections use the filtered inventory; stale remote
+defaults fall back to an available model and explicit removed selections fail.
+Historical preset helpers retain their original model lists and metadata for
+exact configuration-migration matching. Custom connections and voice inventory
+are outside this Google chat override.
+
+Research: Google's [Interactions overview](https://ai.google.dev/gemini-api/docs/interactions-overview)
+still lists Gemini 2.5 and says `generateContent` remains supported. This exclusion
+is Aiden's requested product policy, not a claim that every Google endpoint has
+retired 2.5. The existing Pi `google-generative-ai` transport stays in place;
+adopting Interactions would separately require streaming/tool/caching and storage
+semantics work (its default is `store=true`).
+
+Focused catalog, discovery, migration, remote projection, and selection tests
+cover the override. Both native pickers render the host-provided model list;
+there is no wire-schema or native UI change.
+
+### Original implementation
+
 - Option A is accepted: Aiden reads full executable model records only from the fixed
   `https://pi.dev` provider endpoint. Requests carry a static versioned Aiden/Pi
   User-Agent and never provider credentials, chat content, install IDs, or models.dev data.

--- a/main/services/aiden-remote-models.test.ts
+++ b/main/services/aiden-remote-models.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { AidenRemoteModelService } from "./aiden-remote-models.js";
 import type { Provider } from "./types.js";
+import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
+import { withPiRemoteCatalog } from "./pi-remote-catalog.js";
 
 function provider(overrides: Partial<Provider> = {}): Provider {
   return {
@@ -26,6 +28,22 @@ function provider(overrides: Partial<Provider> = {}): Provider {
     ...overrides,
   };
 }
+
+test("mobile catalogs omit legacy Google models and recover stale defaults", async () => {
+  const google = builtinProviders().find((entry) => entry.id === "google");
+  assert.ok(google);
+  const models = withPiRemoteCatalog(google).getModels().map((model) => model.id);
+  const service = new AidenRemoteModelService({
+    listProviders: async () => [provider({ id: "google", models, modelMetadata: {} })],
+    getSettings: async () => ({ lastProviderId: "google", lastModel: "gemini-2.5-flash" }),
+  });
+  const catalog = await service.list();
+  assert.ok(catalog.providers[0]?.models.length);
+  assert.ok(catalog.providers[0]?.models.every((model) => !/^gemini-(?:2\.5|2\.0|1\.5)(?:-|$)/u.test(model.id)));
+  assert.ok(catalog.defaults.modelId && models.includes(catalog.defaults.modelId));
+  await assert.rejects(service.resolve("google", "gemini-2.5-flash"),
+    (error: unknown) => (error as { code?: string }).code === "invalid_request");
+});
 
 test("model projection includes only configured chat models and no connection secrets", async () => {
   const service = new AidenRemoteModelService({


### PR DESCRIPTION
Verify that the Google catalog exclusion reaches native-client catalog projections: removed models are absent, a saved Gemini 2.5 default falls back to an available model, and an explicit removed-model selection is rejected. Document the override, its scope, and the Gemini Interactions API research.

Both native pickers render the host-provided model list, so no wire schema or native UI implementation changes are needed.

Validation: 93 focused catalog, discovery, migration, remote projection, and selection tests passed; changed-file ESLint passed. CI will run the full repository checks.

Stack: depends on the Google legacy catalog policy PR. Merge the parent first. Each file is committed separately.

Parent: #107.
